### PR TITLE
Move ref_patch_size at target spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ wandb/*
 output/*
 outputs/*
 scripts/*
+notebooks/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -28,9 +28,9 @@ seg_params:
   save_mask: True # save tissue mask to disk as a .jpg image
 
 filter_params:
-  ref_patch_size: 512 # reference patch size at level 0
-  a_t: 16 # area filter threshold for tissue (positive integer, the minimum size of detected foreground contours to consider, relative to the reference patch size ref_patch_size at level 0, e.g. a value 10 means only detected foreground contours of size greater than 10 [ref_patch_size, ref_patch_size] sized patches at level 0 will be processed)
-  a_h: 4 # area filter threshold for holes (positive integer, the minimum size of detected holes/cavities in foreground contours to avoid, once again relative to the reference patch size ref_patch_size at level 0)
+  ref_patch_size: 512 # reference patch size at spacing patch_params.spacing
+  a_t: 16 # area filter threshold for tissue (positive integer, the minimum size of detected foreground contours to consider, relative to the reference patch size ref_patch_size, e.g. a value 10 means only detected foreground contours of size greater than 10 [ref_patch_size, ref_patch_size] sized patches at spacing patch_params.spacing will be processed)
+  a_h: 4 # area filter threshold for holes (positive integer, the minimum size of detected holes/cavities in foreground contours to avoid, once again relative to the reference patch size ref_patch_size)
   max_n_holes: 8 # maximum of holes to consider per detected foreground contours (positive integer, higher values lead to more accurate patching but increase computational cost ; keeps the biggest holes)
 
 vis_params:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,7 +1,7 @@
-slide_list: 'data/debug.txt' # path to the .txt file containing slides paths
+slide_list: 'data/debug_tcga.txt' # path to the .txt file containing slides paths
 
 output_dir: 'output' # folder where to save algorithm output
-experiment_name: 'debug'
+experiment_name: 'debug_tcga'
 resume: False # whether or not to resume existing experiment
 
 wandb:
@@ -28,7 +28,7 @@ seg_params:
   save_mask: True # save tissue mask to disk as a .jpg image
 
 filter_params:
-  ref_patch_size: 512 # reference patch size at spacing patch_params.spacing
+  ref_patch_size: 256 # reference patch size at spacing patch_params.spacing
   a_t: 16 # area filter threshold for tissue (positive integer, the minimum size of detected foreground contours to consider, relative to the reference patch size ref_patch_size, e.g. a value 10 means only detected foreground contours of size greater than 10 [ref_patch_size, ref_patch_size] sized patches at spacing patch_params.spacing will be processed)
   a_h: 4 # area filter threshold for holes (positive integer, the minimum size of detected holes/cavities in foreground contours to avoid, once again relative to the reference patch size ref_patch_size)
   max_n_holes: 8 # maximum of holes to consider per detected foreground contours (positive integer, higher values lead to more accurate patching but increase computational cost ; keeps the biggest holes)

--- a/source/wsi.py
+++ b/source/wsi.py
@@ -53,6 +53,7 @@ class WholeSlideImage(object):
 
     def segmentTissue(
         self,
+        spacing: float,
         seg_level: int = 0,
         sthresh: int = 20,
         sthresh_up: int = 255,
@@ -137,7 +138,10 @@ class WholeSlideImage(object):
 
         self.binary_mask = img_thresh
 
-        scale = self.level_downsamples[seg_level]
+        spacing_level = self.get_best_level_for_spacing(spacing)
+        current_scale = self.level_downsamples[spacing_level]
+        target_scale = self.level_downsamples[seg_level]
+        scale = tuple(a/b for a,b in zip(target_scale,current_scale))
         ref_patch_size = filter_params["ref_patch_size"]
         scaled_ref_patch_area = int(ref_patch_size**2 / (scale[0] * scale[1]))
 
@@ -157,8 +161,8 @@ class WholeSlideImage(object):
                 contours, hierarchy, filter_params
             )
 
-        self.contours_tissue = self.scaleContourDim(foreground_contours, scale)
-        self.holes_tissue = self.scaleHolesDim(hole_contours, scale)
+        self.contours_tissue = self.scaleContourDim(foreground_contours, target_scale)
+        self.holes_tissue = self.scaleHolesDim(hole_contours, target_scale)
 
     def visWSI(
         self,

--- a/utils.py
+++ b/utils.py
@@ -74,6 +74,7 @@ def initialize_wandb(
 
 def segment(
     wsi_object: WholeSlideImage,
+    spacing: float,
     seg_params: DictConfig,
     filter_params: DictConfig,
     mask_file: Optional[Path] = None,
@@ -83,6 +84,7 @@ def segment(
         wsi_object.initSegmentation(mask_file)
     else:
         wsi_object.segmentTissue(
+            spacing=spacing,
             seg_level=seg_params.seg_level,
             sthresh=seg_params.sthresh,
             mthresh=seg_params.mthresh,
@@ -248,6 +250,7 @@ def seg_and_patch(
             if seg:
                 wsi_object, seg_time_elapsed = segment(
                     wsi_object,
+                    patch_params.spacing,
                     seg_params,
                     filter_params,
                 )


### PR DESCRIPTION
In original implementation, `ref_patch_size` was linked to level 0.
Given we may not know the pixel spacing at level 0, I found it more convenient to link `ref_patch_size` to target patching spacing.

Let's say slide `wsi` has pixel spacing 0.25 at level 0 and 0.5 at level 1.
We want to extract [4096,4096] patches at spacing 0.5.

- before, we needed to set `ref_patch_size = 512` so that we got `ref_patch_size` equal to `256` at level 1
- now, we can directly set `ref_patch_size = 256`