### PR TITLE
Add multiprocessing

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -4,14 +4,6 @@ output_dir: 'output' # folder where to save algorithm output
 experiment_name: 'debug'
 resume: False # whether or not to resume existing experiment
 
-wandb:
-  enable: False
-  project: 'hs2p'
-  exp_name: '${experiment_name}'
-  username: 'username'
-  dir: '/home/user'
-  group:
-
 flags:
   seg: True # whether or not to compute tissue segmentation masks
   patch: True # whether or not to extract patches from segmented tissue regions
@@ -54,3 +46,14 @@ patch_params:
     - 214
     - 233
     - 238
+
+speed:
+  multiprocessing: True
+
+wandb:
+  enable: False
+  project: 'hs2p'
+  exp_name: '${experiment_name}'
+  username: 'username'
+  dir: '/home/user'
+  group:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,4 +1,4 @@
-slide_list: 'data/debug.txt' # path to the .txt file containing slides paths
+slide_list: 'data/debug/debug.txt' # path to the .txt file containing slides paths
 
 output_dir: 'output' # folder where to save algorithm output
 experiment_name: 'debug'
@@ -33,7 +33,7 @@ vis_params:
 
 patch_params:
   spacing: 0.5 # pixel spacing (in micron/pixel) at which patches should be extracted (will find the level with spacing the closest to this value)
-  patch_size: 4096 # patch size at previous pixel spacing
+  patch_size: 2048 # patch size at previous pixel spacing
   overlap: 0. # percentage of overlap between two consecutive patches (float between 0 and 1)
   use_padding: True # whether to pad the border of the slide
   contour_fn: 'pct' # contour checking function to decide whether a patch should be considered foreground or background (choices between 'pct' - checks if the given patch has enough tissue using the following parameter as decision threshold, 'four_pt' - checks if all four points in a small grid around the center of the patch are inside the contour, 'center' - checks if the center of the patch is inside the contour, 'basic' - checks if the top-left corner of the patch is inside the contour)
@@ -51,7 +51,7 @@ speed:
   multiprocessing: True
 
 wandb:
-  enable: False
+  enable: True
   project: 'hs2p'
   exp_name: '${experiment_name}'
   username: 'clemsg'

--- a/log_nproc.py
+++ b/log_nproc.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     while not stop:
         nproc = main(args["output_dir"], args["fmt"])
         if nproc > previous_nproc:
-            wandb.log({"processed": nproc+1})
+            wandb.log({"processed": nproc})
             print(f'nslide processed: {nproc}/{args["total"]}', end="\r")
         time.sleep(args["freq"])
         stop = (nproc == args["total"])

--- a/log_nproc.py
+++ b/log_nproc.py
@@ -1,0 +1,40 @@
+import time
+import wandb
+from pathlib import Path
+
+
+def main(output_dir: Path, fmt: str = 'jpg'):
+
+    processed = [fp for fp in Path(output_dir).glob(f"*.{fmt}")]
+    nproc = len(processed)
+    return nproc
+
+
+if __name__ == "__main__":
+
+    import sys
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--id', help='id of the corresponding main experiment', required=True)
+    parser.add_argument('--output_dir', help='directory where main experiment output is saved', required=True)
+    parser.add_argument('--fmt', help='file format of main experiment saved output', required=True)
+    parser.add_argument('--total', type=int, help='total number of output files expected', required=True)
+    parser.add_argument('--freq', type=int, help='time between two consecutive logging calls (in seconds)', default=5)
+    args = vars(parser.parse_args())
+
+    run = wandb.init(id=args["id"])
+    run.define_metric("processed", summary="max")
+    print()
+    stop = False
+    previous_nproc = 0
+    while not stop:
+        nproc = main(args["output_dir"], args["fmt"])
+        if nproc > previous_nproc:
+            wandb.log({"processed": nproc+1})
+            print(f'nslide processed: {nproc}/{args["total"]}', end="\r")
+        time.sleep(args["freq"])
+        stop = (nproc == args["total"])
+        previous_nproc = nproc
+
+    sys.exit()

--- a/log_nproc.py
+++ b/log_nproc.py
@@ -3,7 +3,7 @@ import wandb
 from pathlib import Path
 
 
-def main(output_dir: Path, fmt: str = 'jpg'):
+def main(output_dir: Path, fmt: str = "jpg"):
 
     processed = [fp for fp in Path(output_dir).glob(f"*.{fmt}")]
     nproc = len(processed)
@@ -16,11 +16,26 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--id', help='id of the corresponding main experiment', required=True)
-    parser.add_argument('--output_dir', help='directory where main experiment output is saved', required=True)
-    parser.add_argument('--fmt', help='file format of main experiment saved output', required=True)
-    parser.add_argument('--total', type=int, help='total number of output files expected', required=True)
-    parser.add_argument('--freq', type=int, help='time between two consecutive logging calls (in seconds)', default=5)
+    parser.add_argument(
+        "--id", help="id of the corresponding main experiment", required=True
+    )
+    parser.add_argument(
+        "--output_dir",
+        help="directory where main experiment output is saved",
+        required=True,
+    )
+    parser.add_argument(
+        "--fmt", help="file format of main experiment saved output", required=True
+    )
+    parser.add_argument(
+        "--total", type=int, help="total number of output files expected", required=True
+    )
+    parser.add_argument(
+        "--freq",
+        type=int,
+        help="time between two consecutive logging calls (in seconds)",
+        default=5,
+    )
     args = vars(parser.parse_args())
 
     run = wandb.init(id=args["id"])
@@ -34,7 +49,7 @@ if __name__ == "__main__":
             wandb.log({"processed": nproc})
             print(f'nslide processed: {nproc}/{args["total"]}', end="\r")
         time.sleep(args["freq"])
-        stop = (nproc == args["total"])
+        stop = nproc == args["total"]
         previous_nproc = nproc
 
     sys.exit()

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 import os
-import tqdm
-import wandb
 import hydra
 import shutil
+import datetime
+import subprocess
 import pandas as pd
 import multiprocessing as mp
 
@@ -16,13 +16,15 @@ from utils import initialize_wandb, seg_and_patch, seg_and_patch_slide
 @hydra.main(version_base="1.2.0", config_path="config", config_name="default")
 def main(cfg: DictConfig):
 
+    run_id = datetime.datetime.now().strftime('%Y-%m-%d_%H_%M')
     # set up wandb
     if cfg.wandb.enable:
         key = os.environ.get("WANDB_API_KEY")
         wandb_run = initialize_wandb(cfg, key=key)
         wandb_run.define_metric("processed", summary="max")
+        run_id = wandb_run.id
 
-    output_dir = Path(cfg.output_dir, cfg.experiment_name)
+    output_dir = Path(cfg.output_dir, cfg.experiment_name, run_id)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     mask_save_dir = Path(output_dir, "masks")
@@ -60,12 +62,15 @@ def main(cfg: DictConfig):
         else:
             df = pd.read_csv(process_list_fp)
             df = initialize_df(df, cfg.seg_params, cfg.filter_params, cfg.vis_params, cfg.patch_params)
+
         mask = df["process"] == 1
         process_stack = df[mask]
         slide_paths_to_process = process_stack.slide_path
         slide_ids_to_process = process_stack.slide_id
         args = [
             (
+                df,
+                output_dir,
                 patch_save_dir,
                 mask_save_dir,
                 visu_save_dir,
@@ -81,22 +86,15 @@ def main(cfg: DictConfig):
                 cfg.flags.verbose,
             ) for fp, sid in zip(slide_paths_to_process, slide_ids_to_process)
         ]
+
+        if cfg.wandb.enable:
+            subprocess.Popen(["python3", "log_nproc.py", "--id", f"{run_id}", "--output_dir", f"{visu_save_dir}", "--fmt", "jpg", "--total", f"{len(process_stack)}"])
+
         num_workers = mp.cpu_count()
         if num_workers > 10:
             num_workers = 10
-        results = []
         with mp.Pool(num_workers) as pool:
-            for i, r in enumerate(tqdm.tqdm(pool.starmap(seg_and_patch_slide, args), total=len(args))):
-                results.append(r)
-                if cfg.wandb.enable:
-                    wandb.log({"processed": i+1})
-        for s, sid, vl, sl in results:
-            row = df.loc[df.slide_id == sid]
-            row.status = s
-            row.process = 0
-            row.vis_level = vl
-            row.seg_level = sl
-        df.to_csv(Path(output_dir, "process_list.csv"), index=False)
+            results = pool.starmap(seg_and_patch_slide, args)
 
     else:
 

--- a/main.py
+++ b/main.py
@@ -88,7 +88,8 @@ def main(cfg: DictConfig):
         with mp.Pool(num_workers) as pool:
             for i, r in enumerate(tqdm.tqdm(pool.starmap(seg_and_patch_slide, args), total=len(args))):
                 results.append(r)
-                wandb.log({"processed": i+1})
+                if cfg.wandb.enable:
+                    wandb.log({"processed": i+1})
         for s, sid, vl, sl in results:
             row = df.loc[df.slide_id == sid]
             row.status = s

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from utils import initialize_wandb, seg_and_patch, seg_and_patch_slide
 @hydra.main(version_base="1.2.0", config_path="config", config_name="default")
 def main(cfg: DictConfig):
 
-    run_id = datetime.datetime.now().strftime('%Y-%m-%d_%H_%M')
+    run_id = datetime.datetime.now().strftime("%Y-%m-%d_%H_%M")
     # set up wandb
     if cfg.wandb.enable:
         key = os.environ.get("WANDB_API_KEY")
@@ -28,7 +28,12 @@ def main(cfg: DictConfig):
     output_dir.mkdir(parents=True, exist_ok=True)
 
     mask_save_dir = Path(output_dir, "masks")
-    patch_save_dir = Path(output_dir, "patches", f"{cfg.patch_params.patch_size}", f"{cfg.patch_params.format}")
+    patch_save_dir = Path(
+        output_dir,
+        "patches",
+        f"{cfg.patch_params.patch_size}",
+        f"{cfg.patch_params.format}",
+    )
     visu_save_dir = Path(output_dir, "visualization", f"{cfg.patch_params.patch_size}")
 
     directories = {
@@ -45,10 +50,10 @@ def main(cfg: DictConfig):
         else:
             dirpath.mkdir(parents=True, exist_ok=True)
 
-    if cfg.slide_csv.endswith('.txt'):
-        with open(cfg.slide_csv, 'r') as f:
+    if cfg.slide_csv.endswith(".txt"):
+        with open(cfg.slide_csv, "r") as f:
             slide_paths = [x.strip() for x in f.readlines()]
-        slide_df = pd.DataFrame.from_dict({'slide_path': slide_paths})
+        slide_df = pd.DataFrame.from_dict({"slide_path": slide_paths})
     else:
         slide_df = pd.read_csv(cfg.slide_csv)
 
@@ -67,11 +72,18 @@ def main(cfg: DictConfig):
 
         if process_list_fp is None:
             df = initialize_df(
-                slide_paths, mask_paths, cfg.seg_params, cfg.filter_params, cfg.vis_params, cfg.patch_params
+                slide_paths,
+                mask_paths,
+                cfg.seg_params,
+                cfg.filter_params,
+                cfg.vis_params,
+                cfg.patch_params,
             )
         else:
             df = pd.read_csv(process_list_fp)
-            df = initialize_df(df, cfg.seg_params, cfg.filter_params, cfg.vis_params, cfg.patch_params)
+            df = initialize_df(
+                df, cfg.seg_params, cfg.filter_params, cfg.vis_params, cfg.patch_params
+            )
 
         mask = df["process"] == 1
         process_stack = df[mask]
@@ -95,11 +107,27 @@ def main(cfg: DictConfig):
                 cfg.flags.patch,
                 cfg.flags.visu,
                 cfg.flags.verbose,
-            ) for sid, slide_fp, mask_fp in zip(slide_ids_to_process, slide_paths_to_process, mask_paths_to_process)
+            )
+            for sid, slide_fp, mask_fp in zip(
+                slide_ids_to_process, slide_paths_to_process, mask_paths_to_process
+            )
         ]
 
         if cfg.wandb.enable:
-            subprocess.Popen(["python3", "log_nproc.py", "--id", f"{run_id}", "--output_dir", f"{visu_save_dir}", "--fmt", "jpg", "--total", f"{len(process_stack)}"])
+            subprocess.Popen(
+                [
+                    "python3",
+                    "log_nproc.py",
+                    "--id",
+                    f"{run_id}",
+                    "--output_dir",
+                    f"{visu_save_dir}",
+                    "--fmt",
+                    "jpg",
+                    "--total",
+                    f"{len(process_stack)}",
+                ]
+            )
 
         num_workers = mp.cpu_count()
         if num_workers > 10:
@@ -113,10 +141,10 @@ def main(cfg: DictConfig):
         for t_df, sid, s, vl, sl in results:
 
             mask = df["slide_id"] == sid
-            df.loc[mask, 'status'] = s
-            df.loc[mask, 'process'] = 0
-            df.loc[mask, 'vis_level'] = vl
-            df.loc[mask, 'seg_level'] = sl
+            df.loc[mask, "status"] = s
+            df.loc[mask, "process"] = 0
+            df.loc[mask, "vis_level"] = vl
+            df.loc[mask, "seg_level"] = sl
 
             dfs.append(t_df)
 

--- a/main.py
+++ b/main.py
@@ -1,10 +1,14 @@
 import os
 import hydra
 import shutil
+import pandas as pd
+import multiprocessing as mp
+
 from pathlib import Path
 from omegaconf import DictConfig
 
-from utils import initialize_wandb, seg_and_patch
+from source.utils import initialize_df
+from utils import initialize_wandb, seg_and_patch, seg_and_patch_slide
 
 
 @hydra.main(version_base="1.2.0", config_path="config", config_name="default")
@@ -38,7 +42,7 @@ def main(cfg: DictConfig):
         else:
             dirpath.mkdir(parents=True, exist_ok=True)
 
-    slide_list = Path(cfg.slide_list)
+    slide_paths_fp = Path(cfg.slide_list)
 
     process_list_fp = None
     if Path(output_dir, "process_list.csv").is_file() and cfg.resume:
@@ -46,23 +50,68 @@ def main(cfg: DictConfig):
 
     print()
 
-    seg_times, patch_times = seg_and_patch(
-        output_dir,
-        patch_save_dir,
-        mask_save_dir,
-        visu_save_dir,
-        slide_list=slide_list,
-        seg=cfg.flags.seg,
-        patch=cfg.flags.patch,
-        visu=cfg.flags.visu,
-        process_list=process_list_fp,
-        seg_params=cfg.seg_params,
-        filter_params=cfg.filter_params,
-        vis_params=cfg.vis_params,
-        patch_params=cfg.patch_params,
-        verbose=cfg.flags.verbose,
-        log_to_wandb=cfg.wandb.enable,
-    )
+    if cfg.speed.multiprocessing:
+
+        with open(slide_paths_fp, "r") as f:
+            slide_paths = sorted([s.strip() for s in f])
+        if process_list_fp is None:
+            df = initialize_df(slide_paths, cfg.seg_params, cfg.filter_params, cfg.vis_params, cfg.patch_params)
+        else:
+            df = pd.read_csv(process_list_fp)
+            df = initialize_df(df, cfg.seg_params, cfg.filter_params, cfg.vis_params, cfg.patch_params)
+        mask = df["process"] == 1
+        process_stack = df[mask]
+        slide_paths_to_process = process_stack.slide_path
+        slide_ids_to_process = process_stack.slide_id
+        args = [
+            (
+                patch_save_dir,
+                mask_save_dir,
+                visu_save_dir,
+                cfg.seg_params,
+                cfg.filter_params,
+                cfg.vis_params,
+                cfg.patch_params,
+                Path(fp),
+                sid,
+                cfg.flags.seg,
+                cfg.flags.patch,
+                cfg.flags.visu,
+                cfg.flags.verbose,
+            ) for fp, sid in zip(slide_paths_to_process, slide_ids_to_process)
+        ]
+        num_workers = mp.cpu_count()
+        if num_workers > 4:
+            num_workers = 4
+        with mp.Pool(num_workers) as pool:
+            results = pool.starmap(seg_and_patch_slide, args)
+        for s, sid, vl, sl in results:
+            row = df.loc[df.slide_id == sid]
+            row.status = s
+            row.process = 0
+            row.vis_level = vl
+            row.seg_level = sl
+        df.to_csv(Path(output_dir, "process_list.csv"), index=False)
+
+    else:
+
+        seg_times, patch_times = seg_and_patch(
+            output_dir,
+            patch_save_dir,
+            mask_save_dir,
+            visu_save_dir,
+            slide_paths_fp=slide_paths_fp,
+            seg=cfg.flags.seg,
+            patch=cfg.flags.patch,
+            visu=cfg.flags.visu,
+            process_list=process_list_fp,
+            seg_params=cfg.seg_params,
+            filter_params=cfg.filter_params,
+            vis_params=cfg.vis_params,
+            patch_params=cfg.patch_params,
+            verbose=cfg.flags.verbose,
+            log_to_wandb=cfg.wandb.enable,
+        )
 
 
 if __name__ == "__main__":

--- a/source/wsi.py
+++ b/source/wsi.py
@@ -47,20 +47,24 @@ class WholeSlideImage(object):
     def initSegmentation(self, mask_fp: Path):
         # load segmentation results from pickle file
         import pickle
+
         with open(mask_fp, "rb") as f:
             asset_dict = pickle.load(f)
             self.holes_tissue = asset_dict["holes"]
             self.contours_tissue = asset_dict["tissue"]
 
-    def loadSegmentation(self, mask_fp: Path, spacing, filter_params, sthresh_up: int = 255):
+    def loadSegmentation(
+        self, mask_fp: Path, spacing, filter_params, sthresh_up: int = 255
+    ):
         import tifffile
+
         mask = tifffile.imread(mask_fp)
         mask = mask - np.ones_like(mask)
         if np.max(mask) == 1:
             mask = mask * sthresh_up
         w, h = mask.shape
-        x_level = int(np.argmin([abs(x - w) for x,_ in self.level_dim]))
-        y_level = int(np.argmin([abs(y - h) for _,y in self.level_dim]))
+        x_level = int(np.argmin([abs(x - w) for x, _ in self.level_dim]))
+        y_level = int(np.argmin([abs(y - h) for _, y in self.level_dim]))
         assert x_level == y_level
         self.binary_mask = mask
         self.detect_contours(mask, spacing, x_level, filter_params)
@@ -105,9 +109,9 @@ class WholeSlideImage(object):
         self.binary_mask = img_thresh
         self.detect_contours(img_thresh, spacing, seg_level, filter_params)
 
-
-    def detect_contours(self, img_thresh, spacing: float, seg_level: int, filter_params: Dict[str, int]):
-
+    def detect_contours(
+        self, img_thresh, spacing: float, seg_level: int, filter_params: Dict[str, int]
+    ):
         def _filter_contours(contours, hierarchy, filter_params):
             """
             Filter contours by: area.
@@ -160,7 +164,7 @@ class WholeSlideImage(object):
         spacing_level = self.get_best_level_for_spacing(spacing)
         current_scale = self.level_downsamples[spacing_level]
         target_scale = self.level_downsamples[seg_level]
-        scale = tuple(a/b for a,b in zip(target_scale,current_scale))
+        scale = tuple(a / b for a, b in zip(target_scale, current_scale))
         ref_patch_size = filter_params["ref_patch_size"]
         scaled_ref_patch_area = int(ref_patch_size**2 / (scale[0] * scale[1]))
 
@@ -351,25 +355,38 @@ class WholeSlideImage(object):
             y_res = float(self.wsi.properties["tiff.YResolution"]) / 10000
             x_spacing, y_spacing = 1 / x_res, 1 / y_res
         else:
-            raise KeyError("Neither 'openslide.mpp-x' nor 'tiff.XResolution' were found in slide's properties.\nYou may fix this by inspecting one of your slides' properties and add an elif in the code above")
+            raise KeyError(
+                "Neither 'openslide.mpp-x' nor 'tiff.XResolution' were found in slide's properties.\nYou may fix this by inspecting one of your slides' properties and add an elif in the code above"
+            )
         return x_spacing, y_spacing
 
     def get_best_level_for_spacing(self, target_spacing: float):
         x_spacing, y_spacing = self.get_spacings()
-        downsample_x, downsample_y = target_spacing / x_spacing, target_spacing / y_spacing
+        downsample_x, downsample_y = (
+            target_spacing / x_spacing,
+            target_spacing / y_spacing,
+        )
         # get_best_level_for_downsample just chooses the largest level with a downsample less than user's downsample
         # see https://github.com/openslide/openslide/issues/274
         # so I made my own version of get_best_level_for_downsample
         assert self.get_best_level_for_downsample_custom(
             downsample_x
         ) == self.get_best_level_for_downsample_custom(downsample_y)
-        level, above_tol = self.get_best_level_for_downsample_custom(downsample_x, return_tol_status=True)
+        level, above_tol = self.get_best_level_for_downsample_custom(
+            downsample_x, return_tol_status=True
+        )
         if above_tol:
-            print(f'WARNING! The closest natural spacing to the target spacing was more than 15% appart.')
+            print(
+                f"WARNING! The closest natural spacing to the target spacing was more than 15% appart."
+            )
         return level
 
-    def get_best_level_for_downsample_custom(self, downsample, tol: float = 0.2, return_tol_status: bool = False):
-        level = int(np.argmin([abs(x - downsample) for x in self.wsi.level_downsamples]))
+    def get_best_level_for_downsample_custom(
+        self, downsample, tol: float = 0.2, return_tol_status: bool = False
+    ):
+        level = int(
+            np.argmin([abs(x - downsample) for x in self.wsi.level_downsamples])
+        )
         above_tol = abs(self.wsi.level_downsamples[level] / downsample - 1) > tol
         if return_tol_status:
             return level, above_tol
@@ -382,7 +399,7 @@ class WholeSlideImage(object):
         seg_level: int = -1,
         spacing: float = 0.5,
         patch_size: int = 256,
-        overlap: float = 0.,
+        overlap: float = 0.0,
         contour_fn: str = "pct",
         drop_holes: bool = True,
         tissue_thresh: float = 0.01,
@@ -435,7 +452,7 @@ class WholeSlideImage(object):
                 else:
                     save_hdf5(save_path_hdf5, asset_dict, mode="a")
                 if save_patches_to_disk:
-                    patch_save_dir = Path(save_dir, 'imgs')
+                    patch_save_dir = Path(save_dir, "imgs")
                     patch_save_dir.mkdir(parents=True, exist_ok=True)
                     npatch, mins, secs = save_patch(
                         self.wsi,
@@ -458,7 +475,7 @@ class WholeSlideImage(object):
         spacing: float,
         save_dir: Path,
         patch_size: int = 256,
-        overlap: float = 0.,
+        overlap: float = 0.0,
         contour_fn: str = "pct",
         drop_holes: bool = True,
         tissue_thresh: float = 0.01,
@@ -469,7 +486,7 @@ class WholeSlideImage(object):
         verbose: bool = False,
     ):
 
-        step_size = int(patch_size * (1. - overlap))
+        step_size = int(patch_size * (1.0 - overlap))
         patch_level = self.get_best_level_for_spacing(spacing)
         if cont is not None:
             start_x, start_y, w, h = cv2.boundingRect(cont)
@@ -578,7 +595,9 @@ class WholeSlideImage(object):
         else:
             results = []
             for coord in coord_candidates:
-                c = self.process_coord_candidate(coord, contour_holes, ref_patch_size[0], cont_check_fn, drop_holes)
+                c = self.process_coord_candidate(
+                    coord, contour_holes, ref_patch_size[0], cont_check_fn, drop_holes
+                )
                 results.append(c)
             results = np.array([result for result in results if result is not None])
 
@@ -609,8 +628,8 @@ class WholeSlideImage(object):
                 "spacing": [spacing] * npatch,
                 "level": [patch_level] * npatch,
                 "level_dim": [self.level_dim[patch_level]] * npatch,
-                "x": list(results[:,0]),
-                "y": list(results[:,1]),
+                "x": list(results[:, 0]),
+                "y": list(results[:, 1]),
             }
             tile_df = pd.DataFrame.from_dict(df_data)
             return asset_dict, attr_dict, tile_df

--- a/source/wsi.py
+++ b/source/wsi.py
@@ -516,17 +516,22 @@ class WholeSlideImage(object):
             [x_coords.flatten(), y_coords.flatten()]
         ).transpose()
 
-        num_workers = mp.cpu_count()
-        if num_workers > 4:
-            num_workers = 4
-        pool = mp.Pool(num_workers)
+        # num_workers = mp.cpu_count()
+        # if num_workers > 4:
+        #     num_workers = 4
+        # pool = mp.Pool(num_workers)
 
-        iterable = [
-            (coord, contour_holes, ref_patch_size[0], cont_check_fn, drop_holes)
-            for coord in coord_candidates
-        ]
-        results = pool.starmap(WholeSlideImage.process_coord_candidate, iterable)
-        pool.close()
+        # iterable = [
+        #     (coord, contour_holes, ref_patch_size[0], cont_check_fn, drop_holes)
+        #     for coord in coord_candidates
+        # ]
+        # results = pool.starmap(WholeSlideImage.process_coord_candidate, iterable)
+        # pool.close()
+        # results = np.array([result for result in results if result is not None])
+        results = []
+        for coord in coord_candidates:
+            c = self.process_coord_candidate(coord, contour_holes, ref_patch_size[0], cont_check_fn, drop_holes)
+            results.append(c)
         results = np.array([result for result in results if result is not None])
 
         if verbose:

--- a/utils.py
+++ b/utils.py
@@ -403,9 +403,7 @@ def seg_and_patch_slide(
 
     patch_time = -1
     if patch:
-        slide_save_dir = Path(
-            patch_save_dir, slide_id, f"{patch_params.patch_size}"
-        )
+        slide_save_dir = Path(patch_save_dir, slide_id)
         file_path, patch_time = patching(
             wsi_object=wsi_object,
             save_dir=slide_save_dir,

--- a/utils.py
+++ b/utils.py
@@ -177,7 +177,7 @@ def seg_and_patch(
     patch: bool = False,
     process_list: Optional[Path] = None,
     verbose: bool = False,
-    log_to_wandb: bool = False
+    log_to_wandb: bool = False,
 ):
     start_time = time.time()
     slide_paths = slide_df.slide_path.values.tolist()
@@ -366,7 +366,7 @@ def seg_and_patch_slide(
     verbose: bool = False,
 ):
     if verbose:
-        print(f'Processing {slide_id}...')
+        print(f"Processing {slide_id}...")
 
     if mask_fp is not None:
         mask_fp = Path(mask_fp)
@@ -402,16 +402,18 @@ def seg_and_patch_slide(
             f"level_dim {w} x {h} is likely too large for successful segmentation, aborting"
         )
         status = "failed_seg"
-        tile_df = pd.DataFrame.from_dict({
-            "slide_id": [],
-            "tile_size": [],
-            "spacing": [],
-            "level": [],
-            "level_dim": [],
-            "x": [],
-            "y": [],
-            "contour": [],
-        })
+        tile_df = pd.DataFrame.from_dict(
+            {
+                "slide_id": [],
+                "tile_size": [],
+                "spacing": [],
+                "level": [],
+                "level_dim": [],
+                "x": [],
+                "y": [],
+                "contour": [],
+            }
+        )
         return tile_df, slide_id, status, best_vis_level, best_seg_level
 
     seg_time = -1

--- a/utils.py
+++ b/utils.py
@@ -115,6 +115,7 @@ def patching(
     patch_format: str = "png",
     top_left: Optional[List[int]] = None,
     bot_right: Optional[List[int]] = None,
+    enable_mp: bool = True,
     verbose: bool = False,
 ):
 
@@ -133,6 +134,7 @@ def patching(
         patch_format=patch_format,
         top_left=top_left,
         bot_right=bot_right,
+        enable_mp=enable_mp,
         verbose=verbose,
     )
     patch_time_elapsed = time.time() - start_time
@@ -286,6 +288,7 @@ def seg_and_patch(
                     use_padding=patch_params.use_padding,
                     save_patches_to_disk=patch_params.save_patches_to_disk,
                     patch_format=patch_params.format,
+                    enable_mp=True,
                     verbose=verbose,
                 )
                 dfs.append(tile_df)
@@ -444,6 +447,7 @@ def seg_and_patch_slide(
             use_padding=patch_params.use_padding,
             save_patches_to_disk=patch_params.save_patches_to_disk,
             patch_format=patch_params.format,
+            enable_mp=False,
             verbose=verbose,
         )
 


### PR DESCRIPTION
Found a tacky workaround to be able to log progress to wandb almost in real time when using multiprocessing.
The solution consist in kicking off another process which greps the number of output file in the output directory to know how many slides have been processed at a given point in time. Then initialise wandb session with same id & log to the on-going run.