### PR TITLE
Refactor the resuming of the scripts to `slide2vec` style

### DIFF
--- a/patch_sampling.py
+++ b/patch_sampling.py
@@ -25,11 +25,10 @@ def get_args_parser(add_help: bool = True):
         nargs=argparse.REMAINDER,
     )
     parser.add_argument(
-        "--output-dir",
-        "--output_dir",
-        default=None,
+        "--run-id",
         type=str,
-        help="Output directory to save logs and checkpoints",
+        default="",
+        help="Name of output subdirectory",
     )
     return parser
 
@@ -50,13 +49,11 @@ def main(args):
 
     cfg = setup(args, "sampling")
 
-    run_id = datetime.datetime.now().strftime("%Y-%m-%d_%H_%M")
     # set up wandb
     if cfg.wandb.enable:
         key = os.environ.get("WANDB_API_KEY")
         wandb_run = initialize_wandb(cfg, key=key)
         wandb_run.define_metric("processed", summary="max")
-        run_id = wandb_run.id
 
     pixel_mapping = {k: v for e in cfg.pixel_mapping for k, v in e.items()}
     if cfg.color_mapping is not None:
@@ -64,8 +61,9 @@ def main(args):
     else:
         color_mapping = None
 
-    output_dir = Path(cfg.output_dir, cfg.experiment_name, run_id)
+    output_dir = Path(cfg.output_dir, args.run_id)
     output_dir.mkdir(exist_ok=True, parents=True)
+    cfg.output_dir = str(output_dir)
 
     seg_mask_save_dir = Path(output_dir, "segmentation_mask")
     overlay_mask_save_dir = Path(output_dir, "annotation_mask")

--- a/source/utils.py
+++ b/source/utils.py
@@ -23,9 +23,6 @@ def write_config(cfg, output_dir, name="config.yaml"):
 
 
 def get_cfg_from_args(args, default_config):
-    if args.output_dir is not None:
-        args.output_dir = os.path.abspath(args.output_dir)
-        args.opts += [f"output_dir={args.output_dir}"]
     default_cfg = OmegaConf.create(default_config)
     cfg = OmegaConf.load(args.config_file)
     cfg = OmegaConf.merge(default_cfg, cfg, OmegaConf.from_cli(args.opts))


### PR DESCRIPTION
@clemsgrs 

This PR makes the resuming of tiling with the scripts `patch_extraction.py` and `patch_sampling.py` consistent with the [`slide2vec`](https://github.com/clemsgrs/slide2vec) library and adds the feature that if you expand your input CSV with more slides but still resume using an existing `process_list.csv`, it just adds the new slides (based on the slide-id).