### PR TITLE
remove dead wrappers

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,5 +1,11 @@
 # Documentation Notes
 
+## 2026-04-20 — Dead wrapper cleanup
+
+- Removed the no-op `overlay_mask_on_slide` forwarding wrapper from `hs2p.tiling.orchestration`.
+- Pointed `hs2p.api.overlay_mask_on_slide` directly at `hs2p.wsi.overlay_mask_on_slide`.
+- Removed the private `_compute_tissue_fractions` alias from `hs2p.preprocessing` and updated tests to use `compute_tile_coverage` directly.
+
 ## 2026-04-17 — CI test invocation cleanup
 
 - Updated `.github/workflows/pr-test.yaml` so the integration regression step only runs `tests/test_fixture_artifacts_regression.py`, matching the current test tree.

--- a/hs2p/api.py
+++ b/hs2p/api.py
@@ -11,19 +11,14 @@ from hs2p.artifacts import (
     write_process_list,
 )
 from hs2p.configs import FilterConfig, PreviewConfig, SegmentationConfig, TilingConfig
-from hs2p.tiling.orchestration import (
-    overlay_mask_on_slide,
-    tile_slide,
-    tile_slides,
-    write_tiling_preview,
-)
 from hs2p.tiling.tar import (
     _annotation_tar_stem,
     _apply_qc_filtering_to_result,
     _needs_pixel_filtering,
     extract_tiles_to_tar,
 )
-from hs2p.wsi import CoordinateOutputMode, CoordinateSelectionStrategy
+from hs2p.tiling.orchestration import tile_slide, tile_slides, write_tiling_preview
+from hs2p.wsi import CoordinateOutputMode, CoordinateSelectionStrategy, overlay_mask_on_slide
 
 __all__ = [
     "CompatibilitySpec",

--- a/hs2p/preprocessing.py
+++ b/hs2p/preprocessing.py
@@ -49,10 +49,6 @@ from hs2p.tiling.single import (
 from hs2p.wsi.reader import open_slide, select_level, select_level_for_downsample
 
 
-def _compute_tissue_fractions(candidates, tissue_mask, tile_size_lv0, slide_dimensions):
-    return compute_tile_coverage(candidates, tissue_mask, tile_size_lv0, slide_dimensions)
-
-
 __all__ = [
     "ContourResult",
     "TileGeometry",

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -356,39 +356,6 @@ def write_tiling_preview(
     return save_dir / f"{result.sample_id}.jpg"
 
 
-def overlay_mask_on_slide(
-    wsi_path: Path,
-    annotation_mask_path: Path | None,
-    downsample: int,
-    backend: str,
-    palette: np.ndarray | None = None,
-    pixel_mapping: dict[str, int] | None = None,
-    color_mapping: dict[str, list[int] | None] | None = None,
-    alpha: float = 0.5,
-    mask_arr: np.ndarray | None = None,
-    contours=None,
-    outer_border_color: tuple[int, int, int] = (0x25, 0x5E, 0x3B),
-    hole_border_color: tuple[int, int, int] = (0xF2, 0x6B, 0x3A),
-    stroke_thickness: int = 2,
-):
-    from hs2p.wsi import overlay_mask_on_slide as _overlay_mask_on_slide
-    return _overlay_mask_on_slide(
-        wsi_path=wsi_path,
-        annotation_mask_path=annotation_mask_path,
-        downsample=downsample,
-        backend=backend,
-        palette=palette,
-        pixel_mapping=pixel_mapping,
-        color_mapping=color_mapping,
-        alpha=alpha,
-        mask_arr=mask_arr,
-        contours=contours,
-        outer_border_color=outer_border_color,
-        hole_border_color=hole_border_color,
-        stroke_thickness=stroke_thickness,
-    )
-
-
 @dataclass
 class _PendingPreview:
     whole_slide: SlideSpec
@@ -1271,7 +1238,6 @@ def tile_slides(
 
 __all__ = [
     "extract_tiles_to_tar",
-    "overlay_mask_on_slide",
     "tile_slide",
     "tile_slides",
     "write_tiling_preview",

--- a/tasks/2026-04-20-dead-code-cleanup-plan.md
+++ b/tasks/2026-04-20-dead-code-cleanup-plan.md
@@ -1,0 +1,4 @@
+- [x] Remove the no-op `overlay_mask_on_slide` wrapper from `hs2p.tiling.orchestration` and route the public API directly to the real WSI implementation.
+- [x] Remove the private `_compute_tissue_fractions` forwarding helper from `hs2p.preprocessing` and update tests to call `compute_tile_coverage` directly.
+- [x] Run focused tests covering preprocessing coverage, overlay semantics, and public API imports.
+- [x] Record the cleanup in project docs after verification.

--- a/tests/test_preprocessing_core.py
+++ b/tests/test_preprocessing_core.py
@@ -15,6 +15,7 @@ from hs2p.preprocessing import (
     detect_contours,
     generate_tiles,
 )
+from hs2p.tiling.coverage import compute_tile_coverage
 from hs2p.wsi.streaming.plans import resolve_read_step_px
 
 
@@ -48,9 +49,9 @@ def test_compute_tissue_fractions_normalizes_padded_tiles_over_full_tile_area():
     tissue_mask = np.ones((100, 100), dtype=np.uint8)
     candidates = np.array([[80, 80]], dtype=np.int64)
 
-    fractions = preprocessing_mod._compute_tissue_fractions(
+    fractions = compute_tile_coverage(
         candidates=candidates,
-        tissue_mask=tissue_mask,
+        binary_mask=tissue_mask,
         tile_size_lv0=80,
         slide_dimensions=(100, 100),
     )
@@ -63,9 +64,9 @@ def test_compute_tissue_fractions_truncates_projected_tile_origins():
     tissue_mask[1, 1] = 1
     candidates = np.array([[15, 15]], dtype=np.int64)
 
-    fractions = preprocessing_mod._compute_tissue_fractions(
+    fractions = compute_tile_coverage(
         candidates=candidates,
-        tissue_mask=tissue_mask,
+        binary_mask=tissue_mask,
         tile_size_lv0=10,
         slide_dimensions=(30, 30),
     )


### PR DESCRIPTION
## Summary
- remove the no-op `overlay_mask_on_slide` wrapper from `hs2p.tiling.orchestration`
- route `hs2p.api.overlay_mask_on_slide` directly to `hs2p.wsi.overlay_mask_on_slide`
- remove the private `_compute_tissue_fractions` forwarding helper from `hs2p.preprocessing`
- update the preprocessing coverage tests to call `compute_tile_coverage` directly