### PR TITLE
cifs-friendly artifact writes

### DIFF
--- a/hs2p/artifacts.py
+++ b/hs2p/artifacts.py
@@ -10,9 +10,10 @@ import numpy as np
 from hs2p.configs import FilterConfig, SegmentationConfig, TilingConfig
 from hs2p.preprocessing import (
     TilingResult,
-    _save_tiling_result,
     _load_tiling_result_from_paths,
+    _save_tiling_result,
 )
+from hs2p.fileops import promote_temp_file
 
 
 @dataclass(frozen=True)
@@ -334,7 +335,7 @@ def write_process_list(process_rows: list[dict[str, Any]], process_list_path: Pa
         ) as handle:
             temp_path = Path(handle.name)
             pd.DataFrame(process_rows).to_csv(handle, index=False)
-        temp_path.replace(process_list_path)
+        promote_temp_file(temp_path, process_list_path)
         temp_path = None
     finally:
         if temp_path is not None:

--- a/hs2p/fileops.py
+++ b/hs2p/fileops.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import errno
+import shutil
+from pathlib import Path
+
+
+def promote_temp_file(temp_path: Path, target_path: Path) -> None:
+    """Move a completed temp file into place, with a CIFS-friendly fallback."""
+    try:
+        temp_path.replace(target_path)
+        return
+    except OSError as exc:
+        if exc.errno not in {errno.EACCES, errno.EPERM}:
+            raise
+
+    with temp_path.open("rb") as source, target_path.open("wb") as target:
+        shutil.copyfileobj(source, target)

--- a/hs2p/tiling/io.py
+++ b/hs2p/tiling/io.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from hs2p.tiling.generate import canonicalize_tiling_result
 from hs2p.tiling.result import TileGeometry, TilingResult
+from hs2p.fileops import promote_temp_file
 
 COORDINATE_SPACE = "level0_px"
 TILE_ORDER = "x_then_y"
@@ -282,7 +283,7 @@ def _save_tiling_result(
                     tissue_fractions=canonical.tissue_fractions.astype(np.float32, copy=False),
                 )
                 handle.flush()
-            temp_npz_path.replace(npz_path)
+            promote_temp_file(temp_npz_path, npz_path)
             temp_npz_path = None
             committed_npz_path = npz_path
         else:
@@ -297,7 +298,7 @@ def _save_tiling_result(
             temp_meta_path = Path(handle.name)
             handle.write(json.dumps(_build_tiling_metadata(canonical), indent=2, sort_keys=True) + "\n")
             handle.flush()
-        temp_meta_path.replace(meta_path)
+        promote_temp_file(temp_meta_path, meta_path)
         temp_meta_path = None
         committed_npz_path = None
     finally:

--- a/hs2p/tiling/tar.py
+++ b/hs2p/tiling/tar.py
@@ -14,6 +14,7 @@ from PIL import Image
 
 from hs2p.tiling.result import TilingResult
 from hs2p.tile_qc import filter_coordinate_tiles, needs_pixel_qc
+from hs2p.fileops import promote_temp_file
 from hs2p.wsi import iter_tile_records_from_result, open_reader_for_result
 from hs2p.wsi.reader import BatchRegionReader
 
@@ -235,9 +236,9 @@ def extract_tiles_to_tar(
                 )
                 kept_indices.append(record.tile_index)
 
-        temp_tar_path.replace(tar_path)
+        promote_temp_file(temp_tar_path, tar_path)
         temp_tar_path = None
-        temp_manifest_path.replace(manifest_path)
+        promote_temp_file(temp_manifest_path, manifest_path)
         temp_manifest_path = None
     finally:
         if temp_tar_path is not None:

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -1,4 +1,5 @@
 import json
+import errno
 import tempfile
 from dataclasses import replace
 from pathlib import Path
@@ -28,7 +29,7 @@ from hs2p.api import (
     validate_tiling_artifacts,
     write_tiling_preview,
 )
-from hs2p.artifacts import load_whole_slides_from_rows
+from hs2p.artifacts import load_whole_slides_from_rows, write_process_list
 from hs2p.configs import (
     FilterConfig as ConfigsFilterConfig,
     PreviewConfig as ConfigsPreviewConfig,
@@ -2712,6 +2713,25 @@ def test_write_process_list_removes_temp_file_on_failure(monkeypatch, tmp_path: 
 
     assert created_temp_paths
     assert all(not path.exists() for path in created_temp_paths)
+
+
+def test_write_process_list_falls_back_when_replace_is_denied(
+    monkeypatch, tmp_path: Path
+):
+    process_list_path = tmp_path / "process_list.csv"
+    rows = [{"sample_id": "slide-1", "num_tiles": 3}]
+    original_replace = Path.replace
+
+    def _replace(self, target):
+        if Path(target) == process_list_path:
+            raise PermissionError(errno.EACCES, "Permission denied")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _replace)
+
+    write_process_list(rows, process_list_path)
+
+    assert process_list_path.read_text() == "sample_id,num_tiles\nslide-1,3\n"
 
 
 def test_config_dataclasses_apply_package_defaults_for_secondary_parameters():


### PR DESCRIPTION
## What changed
- Added a shared temp-file promotion helper that falls back to a plain copy when `Path.replace()` is denied by the filesystem.
- Routed the artifact writers for `process_list.csv`, tiling sidecars, and tile archives through that helper.
- Added a regression test covering a `PermissionError` during process-list promotion.

## Why
Some CIFS-backed directories reject `replace()`/rename even when the underlying file is writable. That caused `process_list.csv` writes to fail during tiling finalization.