### PR TITLE
fix resume behavior

### DIFF
--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -443,6 +443,7 @@ def _build_success_artifact(
         tiling_preview_path=tiling_preview_path,
         backend=base_artifact.backend,
         requested_backend=base_artifact.requested_backend,
+        annotation=base_artifact.annotation,
     )
 
 
@@ -465,9 +466,76 @@ def _build_success_process_row(
         "coordinates_npz_path": str(artifact.coordinates_npz_path) if artifact.coordinates_npz_path is not None else np.nan,
         "coordinates_meta_path": str(artifact.coordinates_meta_path),
         "tiles_tar_path": str(artifact.tiles_tar_path) if artifact.tiles_tar_path is not None else np.nan,
+        "mask_preview_path": str(artifact.mask_preview_path) if artifact.mask_preview_path is not None else np.nan,
+        "tiling_preview_path": str(artifact.tiling_preview_path) if artifact.tiling_preview_path is not None else np.nan,
         "error": np.nan,
         "traceback": np.nan,
     }
+
+
+def _existing_file_path(value: Any) -> Path | None:
+    path = optional_path(value)
+    if path is None or not path.is_file():
+        return None
+    return path
+
+
+def _same_optional_path(left: Any, right: Any) -> bool:
+    left_path = optional_path(left)
+    right_path = optional_path(right)
+    if left_path is None or right_path is None:
+        return left_path is None and right_path is None
+    return left_path.expanduser().resolve(strict=False) == right_path.expanduser().resolve(strict=False)
+
+
+def _same_optional_value(left: Any, right: Any) -> bool:
+    if left is None or pd.isna(left):
+        return right is None or pd.isna(right)
+    if right is None or pd.isna(right):
+        return False
+    return str(left) == str(right)
+
+
+def _same_optional_int(left: Any, right: Any) -> bool:
+    if left is None or pd.isna(left):
+        return right is None or pd.isna(right)
+    if right is None or pd.isna(right):
+        return False
+    return int(left) == int(right)
+
+
+def _same_tiling_artifacts(row: dict[str, Any], existing_row: dict[str, Any]) -> bool:
+    return (
+        _same_optional_int(row.get("num_tiles"), existing_row.get("num_tiles"))
+        and _same_optional_path(row.get("coordinates_npz_path"), existing_row.get("coordinates_npz_path"))
+        and _same_optional_path(row.get("coordinates_meta_path"), existing_row.get("coordinates_meta_path"))
+        and _same_optional_path(row.get("tiles_tar_path"), existing_row.get("tiles_tar_path"))
+        and _same_optional_value(row.get("requested_backend"), existing_row.get("requested_backend"))
+        and _same_optional_value(row.get("backend"), existing_row.get("backend"))
+    )
+
+
+def _merge_existing_resume_metadata(
+    row: dict[str, Any],
+    existing_row: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if existing_row is None:
+        return row
+    if row.get("tiling_status") != "success" or existing_row.get("tiling_status") != "success":
+        return row
+    if not _same_tiling_artifacts(row, existing_row):
+        return row
+    merged = dict(row)
+    for key, value in existing_row.items():
+        if key not in merged:
+            merged[key] = value
+    for key in ("mask_preview_path", "tiling_preview_path"):
+        if key not in existing_row:
+            continue
+        existing_path = _existing_file_path(existing_row.get(key))
+        if existing_path is not None and optional_path(merged.get(key)) is None:
+            merged[key] = str(existing_path)
+    return merged
 
 
 def _build_failure_process_row(
@@ -848,6 +916,11 @@ def tile_slides(
                     coordinates_meta_path=meta_path,
                     compatibility=compatibility,
                 )
+                artifact = _build_success_artifact(
+                    base_artifact=artifact,
+                    mask_preview_path=_existing_file_path(row.get("mask_preview_path")),
+                    tiling_preview_path=_existing_file_path(row.get("tiling_preview_path")),
+                )
             if read_coordinates_from is not None and artifact is None:
                 artifact = maybe_load_existing_artifacts(
                     whole_slide=whole_slide,
@@ -1033,6 +1106,10 @@ def tile_slides(
         _emit_tiling_progress()
 
     def _record_process_row(row: dict[str, Any]) -> None:
+        row = _merge_existing_resume_metadata(
+            row,
+            existing_successes.get(str(row.get("sample_id"))),
+        )
         process_rows.append(row)
         # Flush after every slide so a crashed run leaves a process_list.csv
         # that resume can use to skip already-completed slides.

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -2428,7 +2428,7 @@ def test_tile_slides_resume_marks_stale_artifact_as_failed(
                 "requested_backend": "asap",
                 "backend": "asap",
                 "tiling_status": "success",
-                "num_tiles": 1,
+                "num_tiles": artifacts.num_tiles,
                 "coordinates_npz_path": str(artifacts.coordinates_npz_path),
                 "coordinates_meta_path": str(artifacts.coordinates_meta_path),
                 "error": np.nan,
@@ -2463,6 +2463,77 @@ def test_tile_slides_resume_marks_stale_artifact_as_failed(
     assert pd.isna(row["coordinates_npz_path"])
     assert pd.isna(row["coordinates_meta_path"])
     assert "image_path mismatch" in row["error"]
+
+
+def test_tile_slides_resume_preserves_extra_columns_and_existing_preview_paths(
+    monkeypatch,
+    tmp_path: Path,
+    tiling_config: TilingConfig,
+    segmentation_config: SegmentationConfig,
+    filter_config: FilterConfig,
+):
+    run_dir = tmp_path / "run"
+    result = _build_preprocessing_result(
+        sample_id="slide-resume",
+        image_path="slide-resume.svs",
+    )
+    artifacts = save_tiling_result(result, output_dir=run_dir)
+    mask_preview_path = run_dir / "preview" / "mask" / "slide-resume.jpg"
+    tiling_preview_path = run_dir / "preview" / "tiling" / "slide-resume.jpg"
+    for path in (mask_preview_path, tiling_preview_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"preview")
+    pd.DataFrame(
+        [
+            {
+                "sample_id": "slide-resume",
+                "annotation": "tissue",
+                "image_path": "slide-resume.svs",
+                "mask_path": np.nan,
+                "requested_backend": "asap",
+                "backend": "asap",
+                "tiling_status": "success",
+                "num_tiles": artifacts.num_tiles,
+                "coordinates_npz_path": str(artifacts.coordinates_npz_path),
+                "coordinates_meta_path": str(artifacts.coordinates_meta_path),
+                "tiles_tar_path": np.nan,
+                "mask_preview_path": str(mask_preview_path),
+                "tiling_preview_path": str(tiling_preview_path),
+                "feature_status": "success",
+                "feature_path": "tile_embeddings/slide-resume.npz",
+                "error": np.nan,
+                "traceback": np.nan,
+            }
+        ]
+    ).to_csv(run_dir / "process_list.csv", index=False)
+
+    monkeypatch.setattr(
+        orchestration_mod,
+        "preprocess_slide",
+        lambda **_: (_ for _ in ()).throw(
+            AssertionError("resumed successful tiles should not be recomputed")
+        ),
+    )
+
+    reused = tile_slides(
+        [SlideSpec(sample_id="slide-resume", image_path=Path("slide-resume.svs"))],
+        tiling=tiling_config,
+        segmentation=segmentation_config,
+        filtering=filter_config,
+        preview=PreviewConfig(save_mask_preview=True, save_tiling_preview=True),
+        output_dir=run_dir,
+        resume=True,
+    )
+
+    assert len(reused) == 1
+    assert reused[0].mask_preview_path == mask_preview_path
+    assert reused[0].tiling_preview_path == tiling_preview_path
+    process_df = pd.read_csv(run_dir / "process_list.csv")
+    row = process_df.to_dict(orient="records")[0]
+    assert row["feature_status"] == "success"
+    assert row["feature_path"] == "tile_embeddings/slide-resume.npz"
+    assert Path(row["mask_preview_path"]) == mask_preview_path
+    assert Path(row["tiling_preview_path"]) == tiling_preview_path
 
 
 def test_tile_slides_logs_failures_in_real_time(


### PR DESCRIPTION
## Summary

  Fix `tile_slides(..., resume=True)` so resumed successful rows preserve existing process-list metadata instead of dropping downstream columns when
  `process_list.csv` is rewritten.

  ## Changes

  - Preserve extra/non-tiling columns from existing successful resume rows when tiling artifacts are unchanged.
  - Restore existing `mask_preview_path` and `tiling_preview_path` for resumed artifacts when preview files still exist on disk.
  - Include preview path columns in success rows written by `tile_slides`.
  - Add regression coverage for preserving downstream columns and preview paths on resume.