### PR TITLE
use spawn for tiling worker pools to avoid fork deadlocks

### DIFF
--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -760,10 +760,6 @@ def _resolve_tiling_worker_allocation(
     return True, outer_workers, inner_workers
 
 
-def _segmentation_requires_spawn(segmentation: SegmentationConfig | None) -> bool:
-    return segmentation is not None and str(segmentation.method).lower() == "sam2"
-
-
 def _resolve_mask_worker_count(
     *, num_workers: int, segmentation: SegmentationConfig | None
 ) -> int:
@@ -782,10 +778,21 @@ def _configure_worker_logging(output_dir: str) -> None:
     setup_logging(output=output_dir, level=logging.INFO)
 
 
-def _process_pool_context(*, use_spawn: bool):
-    if use_spawn:
-        return mp.get_context("spawn")
-    return mp
+def _process_pool_context():
+    """Return the multiprocessing context for the tiling worker pools.
+
+    The pools are created from a parent process that has already imported
+    heavyweight, multi-threaded libraries (torch, OpenCV, the slide backend)
+    and may hold an initialized CUDA context — e.g. slide2vec resolving the GPU
+    count before driving tiling, or SAM2 tissue segmentation running on GPU.
+    Forking such a parent copies only the calling thread but inherits every
+    mutex (glibc malloc arena, OpenMP, CUDA) in its current state; a lock held
+    by another thread at fork time is never released in the child, which then
+    deadlocks the first time it touches that lock. We therefore use ``"spawn"``
+    (a clean interpreter per worker), which is safe both for CPU tiling and for
+    SAM2-on-GPU, since each worker initializes its own CUDA after it starts.
+    """
+    return mp.get_context("spawn")
 
 
 def _write_tiling_preview_from_artifacts(
@@ -1017,11 +1024,7 @@ def tile_slides(
             num_workers=num_workers,
             segmentation=mask_resolution_requests[0].segmentation,
         )
-        mask_requires_spawn = any(
-            _segmentation_requires_spawn(request.segmentation)
-            for request in mask_resolution_requests
-        )
-        mask_pool_module = _process_pool_context(use_spawn=mask_requires_spawn)
+        mask_pool_module = _process_pool_context()
         if mask_worker_count > 1 and len(mask_resolution_requests) > 1:
             with mask_pool_module.Pool(
                 processes=min(mask_worker_count, len(mask_resolution_requests)),
@@ -1056,11 +1059,7 @@ def tile_slides(
         num_workers=num_workers,
         compute_count=len(compute_requests),
     )
-    compute_requires_spawn = any(
-        _segmentation_requires_spawn(request.segmentation) or bool(request.gpu_decode)
-        for request in compute_requests
-    )
-    compute_pool_module = _process_pool_context(use_spawn=compute_requires_spawn)
+    compute_pool_module = _process_pool_context()
     preview_executor = (
         ThreadPoolExecutor(max_workers=max(1, pool_processes))
         if preview is not None and preview.save_tiling_preview

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -1072,7 +1072,10 @@ def test_tile_slides_uses_slide_level_pool_and_preserves_input_order(
             AssertionError("parent should not write tiling artifacts in pooled mode")
         ),
     )
-    monkeypatch.setattr("hs2p.tiling.orchestration.mp.Pool", _FakePool)
+    monkeypatch.setattr(
+        "hs2p.tiling.orchestration._process_pool_context",
+        lambda: SimpleNamespace(Pool=_FakePool),
+    )
 
     artifacts = tile_slides(
         [
@@ -1151,7 +1154,10 @@ def test_tile_slides_assigns_inner_workers_when_batch_is_small(
         _fake_compute_and_save,
         raising=False,
     )
-    monkeypatch.setattr("hs2p.tiling.orchestration.mp.Pool", _FakePool)
+    monkeypatch.setattr(
+        "hs2p.tiling.orchestration._process_pool_context",
+        lambda: SimpleNamespace(Pool=_FakePool),
+    )
 
     tile_slides(
         [
@@ -1506,7 +1512,11 @@ def test_tile_slides_uses_process_pool_for_tissue_resolution(
         "_compute_and_save_tiling_artifacts_from_request",
         _fake_compute_and_save,
     )
-    monkeypatch.setattr(orchestration_mod.mp, "Pool", _FakePool)
+    monkeypatch.setattr(
+        orchestration_mod,
+        "_process_pool_context",
+        lambda: SimpleNamespace(Pool=_FakePool),
+    )
 
     tile_slides(
         [
@@ -1643,6 +1653,126 @@ def test_tile_slides_uses_spawn_pool_for_sam2_work(
     assert pool_sizes == [2, 2]
     assert worker_outputs == [str(tmp_path), str(tmp_path)]
     assert calls[0] == "_resolve_mask_for_request_safe"
+    assert "_compute_and_save_tiling_artifacts_from_request" in calls
+
+
+def test_process_pool_context_uses_spawn(monkeypatch):
+    assert orchestration_mod._process_pool_context().get_start_method() == "spawn"
+
+
+def test_tile_slides_uses_spawn_pool_for_non_sam2_work(
+    monkeypatch,
+    tmp_path: Path,
+    tiling_config: TilingConfig,
+    segmentation_config: SegmentationConfig,
+    filter_config: FilterConfig,
+):
+    """Regression: CPU/hsv tiling must also use a fork-safe (spawn) pool.
+
+    The tiling pools are created from a parent that has imported heavyweight,
+    multi-threaded libraries (torch, OpenCV, the slide backend) and may hold an
+    initialized CUDA context (e.g. slide2vec resolving the GPU count before
+    driving tiling). Forking such a parent inherits poisoned locks and
+    deadlocks; spawn avoids this for every segmentation method, not just SAM2.
+    """
+    pool_contexts: list[str] = []
+    calls: list[str] = []
+
+    def _fake_resolve_mask_for_request(request):
+        return orchestration_mod._MaskResolutionResponse(
+            input_index=request.input_index,
+            whole_slide=request.whole_slide,
+            ok=True,
+            resolved_mask=preprocessing_mod.ResolvedTissueMask(
+                tissue_mask=np.zeros((8, 8), dtype=np.uint8),
+                tissue_method="hsv",
+                requested_seg_downsample=64,
+                seg_downsample=64,
+                seg_level=0,
+                seg_spacing_um=0.5,
+            ),
+            requested_backend=request.tiling.requested_backend,
+            backend=request.tiling.backend,
+        )
+
+    def _fake_compute_and_save(request):
+        calls.append("_compute_and_save_tiling_artifacts_from_request")
+        tiles_dir = Path(request.output_dir) / "tiles"
+        tiles_dir.mkdir(parents=True, exist_ok=True)
+        npz_path = tiles_dir / f"{request.whole_slide.sample_id}.coordinates.npz"
+        meta_path = tiles_dir / f"{request.whole_slide.sample_id}.coordinates.meta.json"
+        npz_path.write_bytes(b"npz")
+        meta_path.write_text("{}")
+        return SimpleNamespace(
+            input_index=request.input_index,
+            whole_slide=request.whole_slide,
+            ok=True,
+            artifact=TilingArtifacts(
+                sample_id=request.whole_slide.sample_id,
+                coordinates_npz_path=npz_path,
+                coordinates_meta_path=meta_path,
+                num_tiles=1,
+            ),
+            mask_preview_path=None,
+            error=None,
+            traceback_text=None,
+        )
+
+    class _FakePool:
+        def __init__(self, processes, *, initializer=None, initargs=(), **kwargs):
+            if initializer is not None:
+                initializer(*initargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def imap_unordered(self, fn, args_list):
+            calls.append(fn.__name__)
+            for args in args_list:
+                yield fn(args)
+
+    class _FakeContext:
+        def Pool(self, processes, *, initializer=None, initargs=(), **kwargs):
+            return _FakePool(
+                processes,
+                initializer=initializer,
+                initargs=initargs,
+                **kwargs,
+            )
+
+    def _fake_get_context(name):
+        pool_contexts.append(name)
+        return _FakeContext()
+
+    def _unexpected_fork_pool(*args, **kwargs):
+        raise AssertionError("bare mp.Pool (fork) must not be used for tiling")
+
+    monkeypatch.setattr(orchestration_mod, "_resolve_mask_for_request", _fake_resolve_mask_for_request)
+    monkeypatch.setattr(
+        orchestration_mod,
+        "_compute_and_save_tiling_artifacts_from_request",
+        _fake_compute_and_save,
+    )
+    monkeypatch.setattr(orchestration_mod.mp, "get_context", _fake_get_context)
+    monkeypatch.setattr(orchestration_mod.mp, "Pool", _unexpected_fork_pool)
+
+    tile_slides(
+        [
+            SlideSpec(sample_id="slide-1", image_path=Path("slide-1.svs")),
+            SlideSpec(sample_id="slide-2", image_path=Path("slide-2.svs")),
+        ],
+        tiling=tiling_config,
+        segmentation=segmentation_config,
+        filtering=filter_config,
+        output_dir=tmp_path,
+        num_workers=2,
+    )
+
+    # Both the tissue-resolution pool and the compute pool must use spawn.
+    assert pool_contexts == ["spawn", "spawn"]
     assert "_compute_and_save_tiling_artifacts_from_request" in calls
 
 


### PR DESCRIPTION
## Problem

Large tiling jobs driven through slide2vec/soma would tile a handful of slides and then **hang indefinitely** — every worker process (and the parent) stuck in `futex_wait`, 0% CPU, no progress.

Root cause: the mask-resolution and compute tiling pools used the default **`fork`** start method for everything except SAM2. They are created from a parent process that has already imported torch/OpenCV/the slide backend (multi-threaded) and may hold an initialized CUDA context (e.g. slide2vec resolving the GPU count before driving tiling). Forking such a parent copies only the calling thread but inherits every mutex (glibc malloc arena, OpenMP, CUDA) in its current state; a lock held by another thread at fork time is never released in the child, which deadlocks the first time it touches that lock. Under memory pressure (a malloc-arena lock held during the fork) this fired reliably.

## Fix

Always use **`spawn`** for both tiling pools. A clean interpreter per worker is safe for:
- **CPU tiling** (precomputed mask / hsv) — workers need no CUDA, but the parent is fork-unsafe regardless.
- **SAM2-on-GPU** — each worker builds its own predictor and initializes its own CUDA *after* it starts (`sam2_device` is passed as a string, not a live handle).

Since both cases want spawn, the previous SAM2-only branch (`_segmentation_requires_spawn`) collapses into a single path.

## Tests

- `test_process_pool_context_uses_spawn` — the pool context is spawn.
- `test_tile_slides_uses_spawn_pool_for_non_sam2_work` — regression: the CPU/hsv path also uses spawn (the case that deadlocked).
- Updated existing pool tests to intercept at the `_process_pool_context` seam.
- Full tiling suite: 65 passed. Full repo suite: 215 passed, 3 skipped.

Verified end-to-end: initializing a CUDA context in the parent and then tiling 12 slides (the exact old-deadlock setup) now completes 12/12.