### PR TITLE
add spacing-aware read primitive

### DIFF
--- a/hs2p/tiling/generate.py
+++ b/hs2p/tiling/generate.py
@@ -9,7 +9,7 @@ import numpy as np
 from hs2p.tiling.contours import _normalize_level_downsamples
 from hs2p.tiling.coverage import compute_tile_coverage
 from hs2p.tiling.result import ContourResult, TileGeometry, TilingResult
-from hs2p.wsi.reader import select_level
+from hs2p.wsi.geometry import plan_spacing_read
 
 
 def canonicalize_tiling_result(tiles: TileGeometry) -> TileGeometry:
@@ -63,21 +63,17 @@ def generate_tiles(
                 f"fall within tolerance ({tolerance:.0%})"
             )
 
-    level_sel = select_level(
+    level_sel = plan_spacing_read(
         requested_spacing_um=requested_spacing_um,
         level0_spacing_um=base_spacing_um,
         level_downsamples=[
             (float(downsample), float(downsample))
             for downsample in normalized_downsamples
         ],
+        target_size_px=(requested_tile_size_px, requested_tile_size_px),
         tolerance=tolerance,
     )
-    if level_sel.is_within_tolerance:
-        read_tile_size_px = requested_tile_size_px
-    else:
-        read_tile_size_px = round(
-            requested_tile_size_px * requested_spacing_um / level_sel.read_spacing_um
-        )
+    read_tile_size_px = level_sel.read_size_px[0]
     tile_size_lv0 = round(
         read_tile_size_px * level_sel.read_spacing_um / base_spacing_um
     )

--- a/hs2p/wsi/geometry.py
+++ b/hs2p/wsi/geometry.py
@@ -105,3 +105,57 @@ def select_level(
         read_spacing_um=best_spacing,
         is_within_tolerance=is_within_tolerance,
     )
+
+
+@dataclass(frozen=True)
+class SpacingReadPlan:
+    """How to read a region of ``target_size_px`` (at ``requested_spacing_um``).
+
+    ``read_size_px`` is the size to read at ``level`` (its native ``read_spacing_um``)
+    so that, after downscaling to ``target_size_px``, the result is at the requested
+    spacing. When the chosen level is within tolerance the read size equals the target
+    (no scaling — the tiny spacing difference is accepted, never upsampled).
+    """
+
+    level: int
+    read_spacing_um: float
+    is_within_tolerance: bool
+    read_size_px: tuple[int, int]
+
+
+def plan_spacing_read(
+    *,
+    requested_spacing_um: float,
+    level0_spacing_um: float,
+    level_downsamples: list[tuple[float, float]],
+    target_size_px: tuple[int, int],
+    tolerance: float,
+) -> SpacingReadPlan:
+    """Resolve (level, read_size) for reading ``target_size_px`` at a spacing.
+
+    The shared kernel behind both :meth:`hs2p.wsi.wsi.WSI.read_region_at_spacing`
+    and the tiling pipeline's read-size derivation: pick the finest level ``<=`` the
+    requested spacing (via :func:`select_level`), then size the read at that level to
+    cover ``target_size_px`` after downscaling. Within tolerance ⇒ read the target
+    size directly (treated as exact); otherwise scale up by
+    ``requested_spacing_um / read_spacing_um``.
+    """
+    sel = select_level(
+        requested_spacing_um=requested_spacing_um,
+        level0_spacing_um=level0_spacing_um,
+        level_downsamples=level_downsamples,
+        tolerance=tolerance,
+    )
+    target_w, target_h = int(target_size_px[0]), int(target_size_px[1])
+    if sel.is_within_tolerance:
+        read_w, read_h = target_w, target_h
+    else:
+        ratio = float(requested_spacing_um) / float(sel.read_spacing_um)
+        read_w = round(target_w * ratio)
+        read_h = round(target_h * ratio)
+    return SpacingReadPlan(
+        level=sel.level,
+        read_spacing_um=sel.read_spacing_um,
+        is_within_tolerance=sel.is_within_tolerance,
+        read_size_px=(read_w, read_h),
+    )

--- a/hs2p/wsi/masks.py
+++ b/hs2p/wsi/masks.py
@@ -3,6 +3,52 @@ import cv2
 import numpy as np
 
 
+def read_label_at_spacing(
+    wsi,
+    requested_spacing_um: float,
+    *,
+    tolerance: float,
+) -> np.ndarray:
+    """Read a multi-class label raster at ``requested_spacing_um``, preserving class ids.
+
+    Resamples with **nearest-neighbor** (any averaging interpolation would invent
+    class indices) via :meth:`hs2p.wsi.wsi.WSI.read_full_at_spacing`, then recovers a
+    single-channel integer raster. Slide backends return RGB (a single-channel label
+    is replicated across channels); this collapses it back to one channel, asserting
+    the channels agree so a genuine colour image fails loud rather than silently
+    keeping only its red channel.
+
+    Args:
+        wsi: An :class:`hs2p.wsi.wsi.WSI` (or any object exposing
+            ``read_full_at_spacing``).
+        requested_spacing_um: Target spacing (µm/px).
+        tolerance: Relative spacing tolerance for the level match.
+
+    Returns:
+        A 2-D integer ``np.ndarray`` of class indices at the requested spacing.
+    """
+    arr = wsi.read_full_at_spacing(
+        requested_spacing_um, tolerance=tolerance, interpolation="nearest"
+    )
+    if arr.ndim == 3:
+        channels = arr.shape[2]
+        if channels >= 3 and not (
+            np.array_equal(arr[..., 0], arr[..., 1])
+            and np.array_equal(arr[..., 1], arr[..., 2])
+        ):
+            raise ValueError(
+                "label raster has non-identical RGB channels; expected a "
+                "single-channel class-index mask (channel-replicated by the backend), "
+                "not a colour image."
+            )
+        arr = arr[..., 0]
+    if not np.issubdtype(arr.dtype, np.integer):
+        raise ValueError(
+            f"label raster must have an integer dtype (class indices), got {arr.dtype}."
+        )
+    return arr
+
+
 def normalize_tissue_mask(mask_arr: np.ndarray) -> np.ndarray:
     if mask_arr.ndim == 3:
         mask_arr = mask_arr[:, :, 0]

--- a/hs2p/wsi/wsi.py
+++ b/hs2p/wsi/wsi.py
@@ -1,11 +1,45 @@
 from pathlib import Path
 
+import cv2
 import numpy as np
 from PIL import Image
 
 from hs2p.wsi.backend import open_slide, resolve_backend
+from hs2p.wsi.geometry import plan_spacing_read, select_level
 
 Image.MAX_IMAGE_PIXELS = 933120000
+
+# String aliases for cv2 interpolation flags. ``nearest`` is mandatory for label
+# masks (any averaging interpolation invents class indices); ``area`` is the
+# quality default for image downscaling.
+INTERPOLATION_FLAGS = {
+    "nearest": cv2.INTER_NEAREST,
+    "linear": cv2.INTER_LINEAR,
+    "area": cv2.INTER_AREA,
+    "cubic": cv2.INTER_CUBIC,
+    "lanczos": cv2.INTER_LANCZOS4,
+}
+
+
+def resize_array(
+    arr: np.ndarray, target_size: tuple[int, int], *, interpolation: str
+) -> np.ndarray:
+    """Resize ``arr`` to ``target_size`` (width, height) using a named interpolation.
+
+    ``target_size`` matching the current shape is a no-op (returns ``arr`` unchanged),
+    so an exact spacing/level match is lossless.
+    """
+    if interpolation not in INTERPOLATION_FLAGS:
+        raise ValueError(
+            f"unknown interpolation {interpolation!r}; expected one of "
+            f"{sorted(INTERPOLATION_FLAGS)}"
+        )
+    target_width, target_height = int(target_size[0]), int(target_size[1])
+    if arr.shape[1] == target_width and arr.shape[0] == target_height:
+        return arr
+    return cv2.resize(
+        arr, (target_width, target_height), interpolation=INTERPOLATION_FLAGS[interpolation]
+    )
 
 
 class WSI(object):
@@ -171,3 +205,69 @@ class WSI(object):
     def read_region(self, location, level, size):
         """Read a region from the slide at the given level."""
         return self.reader.read_region(location, level, size)
+
+    def read_region_at_spacing(
+        self,
+        location: tuple[int, int],
+        requested_spacing_um: float,
+        size: tuple[int, int],
+        *,
+        tolerance: float,
+        interpolation: str,
+    ) -> np.ndarray:
+        """Read a region at an arbitrary spacing (level-select + downscale).
+
+        Picks the finest pyramid level whose spacing is ``<= requested_spacing_um``
+        (within ``tolerance``) — never upsampling — reads it natively, then downscales
+        to ``size`` (width, height in px at ``requested_spacing_um``) with the named
+        ``interpolation``. When a level matches the requested spacing exactly there is
+        no resize (lossless).
+
+        Args:
+            location: ``(x, y)`` top-left in level-0 pixel space.
+            requested_spacing_um: Target spacing (µm/px).
+            size: Output ``(width, height)`` in pixels at the requested spacing.
+            tolerance: Relative spacing tolerance for the level match (no default —
+                the caller must state it).
+            interpolation: One of :data:`INTERPOLATION_FLAGS`, required so the caller
+                consciously picks it (``"nearest"`` for label masks, ``"area"`` for
+                image downscaling).
+        """
+        plan = plan_spacing_read(
+            requested_spacing_um=float(requested_spacing_um),
+            level0_spacing_um=float(self.get_level_spacing(0)),
+            level_downsamples=self.level_downsamples,
+            target_size_px=(int(size[0]), int(size[1])),
+            tolerance=float(tolerance),
+        )
+        region = self.read_region(location, plan.level, plan.read_size_px)
+        return resize_array(region, (int(size[0]), int(size[1])), interpolation=interpolation)
+
+    def read_full_at_spacing(
+        self,
+        requested_spacing_um: float,
+        *,
+        tolerance: float,
+        interpolation: str,
+    ) -> np.ndarray:
+        """Read the entire image resampled to ``requested_spacing_um``.
+
+        Convenience over :meth:`read_region_at_spacing` for the "read this whole
+        (small) image at a target spacing" case (e.g. a pre-cropped ROI tile): full
+        native read of the finest level ``<=`` the request, then downscale by
+        ``level_spacing / requested_spacing_um``. Exact-level match ⇒ no resize.
+        """
+        sel = select_level(
+            requested_spacing_um=float(requested_spacing_um),
+            level0_spacing_um=float(self.get_level_spacing(0)),
+            level_downsamples=self.level_downsamples,
+            tolerance=float(tolerance),
+        )
+        arr = self.get_slide(sel.level)
+        if sel.is_within_tolerance:
+            # Level matches the request (within tolerance) — read native, no resize.
+            return arr
+        level_height, level_width = arr.shape[0], arr.shape[1]
+        scale = float(sel.read_spacing_um) / float(requested_spacing_um)  # < 1 (downscale)
+        target_size = (int(round(level_width * scale)), int(round(level_height * scale)))
+        return resize_array(arr, target_size, interpolation=interpolation)

--- a/tests/test_spacing_read_primitives.py
+++ b/tests/test_spacing_read_primitives.py
@@ -1,0 +1,226 @@
+"""Tests for the spacing-aware read primitives.
+
+Covers the shared planning kernel (:func:`plan_spacing_read`), the resize helper
+(:func:`resize_array`), and the three public read methods built on them:
+``WSI.read_region_at_spacing``, ``WSI.read_full_at_spacing``, and
+``read_label_at_spacing``. The WSI methods are exercised against a lightweight
+stub (they only touch ``get_level_spacing``, ``level_downsamples``,
+``read_region``, and ``get_slide``) so no slide backend is required.
+"""
+
+import numpy as np
+import pytest
+
+from hs2p.wsi.geometry import plan_spacing_read
+from hs2p.wsi.masks import read_label_at_spacing
+from hs2p.wsi.wsi import WSI, resize_array
+
+# level0 spacing 0.5 µm/px with x1/x2/x4 downsamples -> spacings [0.5, 1.0, 2.0]
+DOWNSAMPLES = [(1.0, 1.0), (2.0, 2.0), (4.0, 4.0)]
+
+
+# --------------------------------------------------------------------------- #
+# plan_spacing_read                                                           #
+# --------------------------------------------------------------------------- #
+def test_plan_spacing_read_exact_match_reads_target_size_directly():
+    plan = plan_spacing_read(
+        requested_spacing_um=0.5,
+        level0_spacing_um=0.5,
+        level_downsamples=DOWNSAMPLES,
+        target_size_px=(100, 100),
+        tolerance=0.05,
+    )
+
+    assert plan.level == 0
+    assert plan.is_within_tolerance is True
+    # within tolerance -> read the target size, no scaling (never upsampled)
+    assert plan.read_size_px == (100, 100)
+
+
+def test_plan_spacing_read_out_of_tolerance_scales_read_size_up():
+    # 1.5 µm/px sits between level1 (1.0) and level2 (2.0); finest level whose
+    # spacing is <= request is level1, so read larger and downscale by 1.5/1.0.
+    plan = plan_spacing_read(
+        requested_spacing_um=1.5,
+        level0_spacing_um=0.5,
+        level_downsamples=DOWNSAMPLES,
+        target_size_px=(100, 100),
+        tolerance=0.05,
+    )
+
+    assert plan.level == 1
+    assert plan.read_spacing_um == pytest.approx(1.0)
+    assert plan.is_within_tolerance is False
+    assert plan.read_size_px == (150, 150)  # round(100 * 1.5 / 1.0)
+
+
+def test_plan_spacing_read_never_selects_a_coarser_level_than_requested():
+    # 0.9 is closest to level1 (1.0) but 1.0 > 0.9, so the kernel steps down to
+    # level0 (0.5) rather than upsample from a coarser level.
+    plan = plan_spacing_read(
+        requested_spacing_um=0.9,
+        level0_spacing_um=0.5,
+        level_downsamples=DOWNSAMPLES,
+        target_size_px=(100, 100),
+        tolerance=0.05,
+    )
+
+    assert plan.level == 0
+    assert plan.read_spacing_um == pytest.approx(0.5)
+    assert plan.is_within_tolerance is False
+    assert plan.read_size_px == (180, 180)  # round(100 * 0.9 / 0.5)
+
+
+# --------------------------------------------------------------------------- #
+# resize_array                                                                #
+# --------------------------------------------------------------------------- #
+def test_resize_array_is_a_noop_when_target_matches_shape():
+    arr = np.arange(4 * 4 * 3, dtype=np.uint8).reshape(4, 4, 3)
+
+    out = resize_array(arr, (4, 4), interpolation="area")
+
+    # identical shape -> same object returned (lossless exact match)
+    assert out is arr
+
+
+def test_resize_array_downscales_with_nearest_preserving_class_ids():
+    labels = np.array(
+        [
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [3, 3, 4, 4],
+            [3, 3, 4, 4],
+        ],
+        dtype=np.int32,
+    )
+
+    out = resize_array(labels, (2, 2), interpolation="nearest")
+
+    assert out.shape == (2, 2)
+    assert set(np.unique(out)).issubset({1, 2, 3, 4})
+
+
+def test_resize_array_rejects_unknown_interpolation():
+    arr = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="unknown interpolation"):
+        resize_array(arr, (2, 2), interpolation="bogus")
+
+
+# --------------------------------------------------------------------------- #
+# WSI.read_region_at_spacing / read_full_at_spacing                           #
+# --------------------------------------------------------------------------- #
+class _StubWSI:
+    """Minimal duck-typed stand-in for the attributes the read methods touch."""
+
+    def __init__(self, *, level0_spacing_um: float, levels: list[np.ndarray]):
+        self._level0_spacing_um = level0_spacing_um
+        self._levels = levels
+        width_0, height_0 = levels[0].shape[1], levels[0].shape[0]
+        self.level_downsamples = [
+            (width_0 / lvl.shape[1], height_0 / lvl.shape[0]) for lvl in levels
+        ]
+
+    def get_level_spacing(self, level: int) -> float:
+        return self._level0_spacing_um * self.level_downsamples[level][0]
+
+    def get_slide(self, level: int) -> np.ndarray:
+        return self._levels[level]
+
+    def read_region(self, location, level, size):
+        x, y = location
+        ds = self.level_downsamples[level][0]
+        arr = self._levels[level]
+        x_l, y_l = int(round(x / ds)), int(round(y / ds))
+        w, h = int(size[0]), int(size[1])
+        return arr[y_l : y_l + h, x_l : x_l + w, :]
+
+
+def test_read_region_at_spacing_exact_match_returns_native_region_unresized():
+    level0 = np.arange(8 * 8 * 3, dtype=np.uint8).reshape(8, 8, 3)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    region = WSI.read_region_at_spacing(
+        stub,
+        location=(2, 2),
+        requested_spacing_um=0.5,
+        size=(4, 4),
+        tolerance=0.05,
+        interpolation="area",
+    )
+
+    # exact spacing match -> read 4x4 natively, no resize
+    np.testing.assert_array_equal(region, level0[2:6, 2:6, :])
+
+
+def test_read_full_at_spacing_exact_match_returns_level_unchanged():
+    level0 = np.arange(4 * 4 * 3, dtype=np.uint8).reshape(4, 4, 3)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    out = WSI.read_full_at_spacing(
+        stub, requested_spacing_um=0.5, tolerance=0.05, interpolation="area"
+    )
+
+    assert out is level0
+
+
+def test_read_full_at_spacing_downscales_when_no_level_matches():
+    level0 = np.ones((4, 4, 3), dtype=np.uint8) * 200
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    # request 1.0 with only a 0.5 level present -> downscale by 0.5/1.0
+    out = WSI.read_full_at_spacing(
+        stub, requested_spacing_um=1.0, tolerance=0.05, interpolation="area"
+    )
+
+    assert out.shape == (2, 2, 3)
+
+
+# --------------------------------------------------------------------------- #
+# read_label_at_spacing                                                       #
+# --------------------------------------------------------------------------- #
+class _StubLabelWSI:
+    def __init__(self, arr: np.ndarray):
+        self._arr = arr
+        self.calls: list[dict] = []
+
+    def read_full_at_spacing(self, requested_spacing_um, *, tolerance, interpolation):
+        self.calls.append(
+            {
+                "requested_spacing_um": requested_spacing_um,
+                "tolerance": tolerance,
+                "interpolation": interpolation,
+            }
+        )
+        return self._arr
+
+
+def test_read_label_at_spacing_collapses_channel_replicated_rgb():
+    labels = np.array([[0, 1], [2, 3]], dtype=np.int32)
+    rgb = np.stack([labels, labels, labels], axis=-1)
+    stub = _StubLabelWSI(rgb)
+
+    out = read_label_at_spacing(stub, requested_spacing_um=2.0, tolerance=0.05)
+
+    np.testing.assert_array_equal(out, labels)
+    # labels must be resampled with nearest-neighbor to avoid inventing ids
+    assert stub.calls == [
+        {"requested_spacing_um": 2.0, "tolerance": 0.05, "interpolation": "nearest"}
+    ]
+
+
+def test_read_label_at_spacing_rejects_genuine_colour_image():
+    colour = np.zeros((2, 2, 3), dtype=np.uint8)
+    colour[..., 0] = 10  # red differs from green/blue -> not a replicated label
+    stub = _StubLabelWSI(colour)
+
+    with pytest.raises(ValueError, match="non-identical RGB channels"):
+        read_label_at_spacing(stub, requested_spacing_um=2.0, tolerance=0.05)
+
+
+def test_read_label_at_spacing_rejects_non_integer_dtype():
+    labels = np.array([[0.0, 1.0], [2.0, 3.0]], dtype=np.float32)
+    stub = _StubLabelWSI(labels)
+
+    with pytest.raises(ValueError, match="integer dtype"):
+        read_label_at_spacing(stub, requested_spacing_um=2.0, tolerance=0.05)


### PR DESCRIPTION
## Summary
Introduces a resolution-agnostic read primitive and threads its level/read-size decision through the existing tiling pipeline, keeping all read sizing in one shared kernel.

- **`WSI.read_region_at_spacing`** (`hs2p/wsi/wsi.py`) — reads a region at an arbitrary spacing: picks the finest pyramid level whose spacing is `<=` the request (never upsampling), reads natively, then downscales to the target size with a caller-chosen interpolation. An exact-level match is lossless (no resize).
- **`plan_spacing_read`** (`hs2p/wsi/geometry.py`) — the shared kernel resolving `(level, read_size_px)`. The tiling pipeline (`hs2p/tiling/generate.py`) now calls it instead of re-deriving read sizes inline, so the primitive and the pipeline can't drift.
- **`resize_array`** (`hs2p/wsi/wsi.py`) — named-interpolation resize that is a no-op on an exact size match (keeps exact reads lossless) and rejects unknown interpolation names.
- **`read_full_at_spacing`** (`hs2p/wsi/wsi.py`) — whole-image convenience over the primitive (e.g. a pre-cropped ROI).
- **`read_label_at_spacing`** (`hs2p/wsi/masks.py`) — nearest-neighbor label resampling that recovers a single-channel integer raster and fails loud on genuine colour images or non-integer dtypes, so class ids are never invented (segmentation-label support).