### PR TITLE
annotation-aware sampling

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -116,7 +116,9 @@ pip install "hs2p[all]"
     are computed relative to those classes. To sample a subset (e.g. only Gleason grades 4
     and 5 from a 6-grade mask), list all grades in `pixel_mapping` so the raster validates,
     but give thresholds only to grades 4 and 5. Because configs are deep-merged over the
-    defaults, set `min_coverage.tissue: null` to drop the default tissue class from sampling.
+    default `{background: 0, tissue: 1}`, set `min_coverage.tissue: null` to drop the default
+    tissue class from sampling, and set `pixel_mapping.tissue: null` to remove the default
+    label entirely (required to reuse its value, e.g. a `tumor: 1` mask).
   - `output_mode` (annotation sampling only): `per_annotation` (default) writes one coordinate
     artifact per sampled class; `single_output` writes one merged per-slide artifact (the
     union of tiles passing any class threshold).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,8 +102,10 @@ pip install "hs2p[all]"
   - `tissue_contour_color` controls the RGB border color used for `preview/mask/*.jpg`
   - `mask_overlay_alpha` controls opacity for the filled annotation-mask overlay path; contour-only previews ignore it
 - `tiling.masks`
-  - multi-label annotation sampling (pixel_mapping, color_mapping, min_coverage)
-  - when absent, defaults to binary tissue tiling
+  - multi-label annotation sampling (pixel_mapping, color_mapping, min_coverage, output_mode)
+  - annotation sampling activates when `pixel_mapping` declares a foreground class other than
+    the default `tissue`; otherwise the CLI runs binary tissue tiling. Each slide's annotation
+    mask is taken from the `mask_path` column of the input CSV.
   - `pixel_mapping` is your own label vocabulary — **no name is reserved** (there is no
     special `background`). It must enumerate **every** label value present in the raster
     (each value distinct, in `[0, 65535]`); any pixel value not declared here makes the mask
@@ -113,7 +115,16 @@ pip install "hs2p[all]"
     (non-null) coverage threshold get tiled, and the coverage report's `frac`/`est_tiles`
     are computed relative to those classes. To sample a subset (e.g. only Gleason grades 4
     and 5 from a 6-grade mask), list all grades in `pixel_mapping` so the raster validates,
-    but give thresholds only to grades 4 and 5.
+    but give thresholds only to grades 4 and 5. Because configs are deep-merged over the
+    defaults, set `min_coverage.tissue: null` to drop the default tissue class from sampling.
+  - `output_mode` (annotation sampling only): `per_annotation` (default) writes one coordinate
+    artifact per sampled class; `single_output` writes one merged per-slide artifact (the
+    union of tiles passing any class threshold).
+  - `tiling.independent_sampling` chooses `independent_sampling` (tile each class separately)
+    vs the default joint sampling (one pass over the union mask, then per-class coverage
+    filtering).
+  - Not yet supported with annotation sampling: `resume`, `read_coordinates_from`, and
+    `save_tiles` raise a clear error if enabled; previews are skipped.
 - `save_tiles`
   - write `tiles/{sample_id}.tiles.tar`
 - `speed.num_workers`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,8 +106,7 @@ pip install "hs2p[all]"
   - annotation sampling activates when `pixel_mapping` declares a foreground class other than
     the default `tissue`; otherwise the CLI runs binary tissue tiling. Each slide's annotation
     mask is taken from the `mask_path` column of the input CSV.
-  - `pixel_mapping` is your own label vocabulary — **no name is reserved** (there is no
-    special `background`). It must enumerate **every** label value present in the raster
+  - `pixel_mapping` is your own label vocabulary: it must enumerate **every** label value present in the raster
     (each value distinct, in `[0, 65535]`); any pixel value not declared here makes the mask
     read fail (the discreteness guard). If the raster reserves a value for unannotated
     pixels, declare it like any other class and simply give it no `min_coverage` threshold.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -104,6 +104,16 @@ pip install "hs2p[all]"
 - `tiling.masks`
   - multi-label annotation sampling (pixel_mapping, color_mapping, min_coverage)
   - when absent, defaults to binary tissue tiling
+  - `pixel_mapping` is your own label vocabulary — **no name is reserved** (there is no
+    special `background`). It must enumerate **every** label value present in the raster
+    (each value distinct, in `[0, 65535]`); any pixel value not declared here makes the mask
+    read fail (the discreteness guard). If the raster reserves a value for unannotated
+    pixels, declare it like any other class and simply give it no `min_coverage` threshold.
+  - `min_coverage` selects **which** classes are actually sampled: only classes given a
+    (non-null) coverage threshold get tiled, and the coverage report's `frac`/`est_tiles`
+    are computed relative to those classes. To sample a subset (e.g. only Gleason grades 4
+    and 5 from a 6-grade mask), list all grades in `pixel_mapping` so the raster validates,
+    but give thresholds only to grades 4 and 5.
 - `save_tiles`
   - write `tiles/{sample_id}.tiles.tar`
 - `speed.num_workers`

--- a/hs2p/__main__.py
+++ b/hs2p/__main__.py
@@ -7,6 +7,7 @@ from hs2p.configs.resolvers import (
     resolve_filter_config,
     resolve_preview_config,
     resolve_read_coordinates_from,
+    resolve_sampling_request,
     resolve_segmentation_config,
     resolve_tiling_config,
 )
@@ -55,6 +56,9 @@ def main(args):
             filtering = resolve_filter_config(cfg)
             preview = resolve_preview_config(cfg)
             read_coordinates_from = resolve_read_coordinates_from(cfg)
+            sampling, selection_strategy, output_mode = resolve_sampling_request(
+                cfg, tiling=tiling
+            )
             jpeg_backend = str(getattr(cfg.speed, "jpeg_backend", "turbojpeg"))
             progress.emit_progress(
                 "run.started",
@@ -70,8 +74,7 @@ def main(args):
                     str(read_coordinates_from) if read_coordinates_from else None
                 ),
             )
-            artifacts = tile_slides(
-                whole_slides,
+            tile_kwargs = dict(
                 tiling=tiling,
                 segmentation=segmentation,
                 filtering=filtering,
@@ -83,6 +86,43 @@ def main(args):
                 save_tiles=bool(getattr(cfg, "save_tiles", False)),
                 jpeg_backend=jpeg_backend,
             )
+            if sampling is not None:
+                # Annotation sampling does not yet support these features; refuse explicit
+                # opt-ins rather than silently ignoring them, and skip previews (which default
+                # on) with a clear notice instead of erroring on every run.
+                unsupported = [
+                    name
+                    for name, enabled in (
+                        ("resume", bool(cfg.resume)),
+                        ("read_coordinates_from", read_coordinates_from is not None),
+                        ("save_tiles", bool(getattr(cfg, "save_tiles", False))),
+                    )
+                    if enabled
+                ]
+                if unsupported:
+                    raise ValueError(
+                        "annotation sampling (tiling.masks declares non-tissue classes) does "
+                        "not yet support: " + ", ".join(unsupported)
+                    )
+                progress.emit_progress(
+                    "sampling.enabled",
+                    selection_strategy=selection_strategy,
+                    output_mode=output_mode,
+                    active_annotations=list(sampling.active_annotations),
+                    previews_skipped=bool(
+                        preview.save_mask_preview or preview.save_tiling_preview
+                    ),
+                )
+                tile_kwargs.update(
+                    preview=None,
+                    resume=False,
+                    read_coordinates_from=None,
+                    save_tiles=False,
+                    sampling=sampling,
+                    selection_strategy=selection_strategy,
+                    output_mode=output_mode,
+                )
+            artifacts = tile_slides(whole_slides, **tile_kwargs)
             progress.emit_progress(
                 "run.finished",
                 command="tiling",

--- a/hs2p/api.py
+++ b/hs2p/api.py
@@ -10,6 +10,9 @@ from hs2p.artifacts import (
     validate_tiling_artifacts,
 )
 from hs2p.configs import FilterConfig, PreviewConfig, SegmentationConfig, TilingConfig
+from hs2p.tiling.coverage import summarize_annotation_coverage
+from hs2p.tiling.mask import resolve_annotation_masks
+from hs2p.tiling.result import ResolvedAnnotationMasks
 from hs2p.tiling.tar import (
     _annotation_tar_stem,
     _apply_qc_filtering_to_result,
@@ -25,6 +28,7 @@ __all__ = [
     "CoordinateSelectionStrategy",
     "FilterConfig",
     "PreviewConfig",
+    "ResolvedAnnotationMasks",
     "SegmentationConfig",
     "SlideSpec",
     "TilingArtifacts",
@@ -33,7 +37,9 @@ __all__ = [
     "load_tiling_result",
     "maybe_load_existing_artifacts",
     "overlay_mask_on_slide",
+    "resolve_annotation_masks",
     "save_tiling_result",
+    "summarize_annotation_coverage",
     "tile_slide",
     "tile_slides",
     "validate_tiling_artifacts",

--- a/hs2p/artifacts.py
+++ b/hs2p/artifacts.py
@@ -41,6 +41,7 @@ class TilingArtifacts:
     backend: str | None = None
     requested_backend: str | None = None
     annotation: str | None = None
+    output_mode: str | None = None
 
 
 @dataclass(frozen=True)
@@ -89,12 +90,32 @@ def validate_result_consistency(result: TilingResult) -> None:
         raise ValueError("tile_index must be a contiguous range from 0 to num_tiles-1")
 
 
+def _ensure_safe_path_component(name: str) -> str:
+    """Reject annotation labels that aren't a single, contained path component.
+
+    Annotation names become directories under ``output_dir/tiles``; a value like ``../outside``
+    or ``/tmp/owned`` would escape the run's output tree. This is enforced at the filesystem
+    boundary so it holds for every caller — the CLI resolver and the public ``tile_slides``
+    API, which accepts a ``SamplingSpec`` directly and never passes through config validation.
+    """
+    if (
+        not name
+        or name in {".", ".."}
+        or any(ch in name for ch in ("/", "\\", "\x00"))
+    ):
+        raise ValueError(
+            f"annotation label {name!r} must be a safe path component "
+            "(non-empty, no '/'\\ separators, not '.' or '..')"
+        )
+    return name
+
+
 def _annotation_tiles_dir(output_dir: Path, annotation: str | None) -> Path:
     """Return the tiles sub-directory, collapsing 'tissue' to the flat layout."""
     base = Path(output_dir) / "tiles"
     if annotation is None or annotation == "tissue":
         return base
-    return base / annotation
+    return base / _ensure_safe_path_component(annotation)
 
 
 def save_tiling_result(
@@ -124,6 +145,7 @@ def save_tiling_result(
         backend=result.backend,
         requested_backend=result.requested_backend,
         annotation=annotation,
+        output_mode=result.output_mode,
     )
 
 

--- a/hs2p/configs/default.yaml
+++ b/hs2p/configs/default.yaml
@@ -61,6 +61,10 @@ tiling:
     tissue_contour_color: [37, 94, 59] # RGB color used for outer tissue contours in batch mask previews
     mask_overlay_alpha: 0.5 # opacity used by the filled annotation-mask overlay path; contour previews ignore this
   masks:
+    # output_mode applies only when annotation sampling is active (pixel_mapping declares
+    # classes beyond the default tissue): per_annotation writes one coordinate artifact per
+    # sampled class; single_output writes one merged per-slide artifact.
+    output_mode: per_annotation
     pixel_mapping: # map annotated categories to their corresponding pixel values
       background: 0
       tissue: 1

--- a/hs2p/configs/resolvers.py
+++ b/hs2p/configs/resolvers.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy as np
 
-from hs2p.wsi.types import CoordinateSelectionStrategy, SamplingSpec
+from hs2p.wsi.types import CoordinateOutputMode, CoordinateSelectionStrategy, SamplingSpec
 
 from .models import FilterConfig, PreviewConfig, SegmentationConfig, TilingConfig
 
@@ -19,7 +19,9 @@ def resolve_tiling_config(cfg: Any) -> TilingConfig:
         requested_tile_size_px=cfg.tiling.params.requested_tile_size_px,
         tolerance=cfg.tiling.params.tolerance,
         overlap=cfg.tiling.params.overlap,
-        tissue_threshold=float(min_coverage["tissue"]),
+        # ``tissue`` is only meaningful for the binary-tissue path; a pure annotation-sampling
+        # config (e.g. only Gleason grades) need not declare it, so default to 0.0 when absent.
+        tissue_threshold=float(min_coverage.get("tissue") or 0.0),
         independent_sampling=bool(cfg.tiling.independent_sampling),
         backend=cfg.tiling.backend,
     )
@@ -57,6 +59,44 @@ def resolve_sampling_strategy(cfg: Any) -> str:
     if independent:
         return CoordinateSelectionStrategy.INDEPENDENT_SAMPLING
     return CoordinateSelectionStrategy.JOINT_SAMPLING
+
+
+def resolve_output_mode(cfg: Any) -> str:
+    """Derive the coordinate output mode from ``tiling.masks.output_mode``.
+
+    ``per_annotation`` (default) writes one coordinate artifact per sampled class;
+    ``single_output`` writes one merged per-slide artifact (the union of tiles passing any
+    class threshold).
+    """
+    masks_cfg = getattr(cfg.tiling, "masks", None)
+    raw = getattr(masks_cfg, "output_mode", None) if masks_cfg is not None else None
+    value = str(raw or CoordinateOutputMode.PER_ANNOTATION).lower()
+    valid = {CoordinateOutputMode.PER_ANNOTATION, CoordinateOutputMode.SINGLE_OUTPUT}
+    if value not in valid:
+        raise ValueError(
+            f"tiling.masks.output_mode must be one of {sorted(valid)}, got {value!r}"
+        )
+    return value
+
+
+def resolve_sampling_request(
+    cfg: Any,
+    *,
+    tiling: TilingConfig,
+) -> tuple[SamplingSpec | None, str | None, str | None]:
+    """Resolve the annotation-sampling invocation for the CLI tiling entrypoint.
+
+    Returns ``(sampling, selection_strategy, output_mode)`` when the masks config declares
+    annotation classes beyond the default binary-tissue setup, else ``(None, None, None)`` so
+    the caller takes the tissue-tiling path. The signal is the declared label vocabulary: a
+    ``pixel_mapping`` of just ``{background, tissue}`` (the default) is binary tissue tiling;
+    declaring any other foreground class opts into multi-label annotation sampling.
+    """
+    spec = resolve_sampling_spec(cfg, tiling=tiling)
+    foreground = set(spec.pixel_mapping) - {"background"}
+    if not spec.active_annotations or foreground <= {"tissue"}:
+        return None, None, None
+    return spec, resolve_sampling_strategy(cfg), resolve_output_mode(cfg)
 
 
 def build_default_sampling_spec(tiling: TilingConfig) -> SamplingSpec:

--- a/hs2p/configs/resolvers.py
+++ b/hs2p/configs/resolvers.py
@@ -86,15 +86,21 @@ def resolve_sampling_request(
 ) -> tuple[SamplingSpec | None, str | None, str | None]:
     """Resolve the annotation-sampling invocation for the CLI tiling entrypoint.
 
-    Returns ``(sampling, selection_strategy, output_mode)`` when the masks config declares
-    annotation classes beyond the default binary-tissue setup, else ``(None, None, None)`` so
-    the caller takes the tissue-tiling path. The signal is the declared label vocabulary: a
-    ``pixel_mapping`` of just ``{background, tissue}`` (the default) is binary tissue tiling;
-    declaring any other foreground class opts into multi-label annotation sampling.
+    Returns ``(sampling, selection_strategy, output_mode)`` when the masks config has been
+    customized away from the shipped default, else ``(None, None, None)`` so the caller takes
+    the binary tissue-tiling path. The signal is configuration, not label names: a spec equal
+    to :func:`build_default_sampling_spec` (the untouched default ``{background, tissue}``
+    setup) is binary tissue tiling; any change to the label vocabulary or the sampled set opts
+    into multi-label annotation sampling. No label name is reserved at this boundary.
     """
     spec = resolve_sampling_spec(cfg, tiling=tiling)
-    foreground = set(spec.pixel_mapping) - {"background"}
-    if not spec.active_annotations or foreground <= {"tissue"}:
+    if not spec.active_annotations:
+        return None, None, None
+    default = build_default_sampling_spec(tiling)
+    is_untouched_default = dict(spec.pixel_mapping) == dict(default.pixel_mapping) and set(
+        spec.active_annotations
+    ) == set(default.active_annotations)
+    if is_untouched_default:
         return None, None, None
     return spec, resolve_sampling_strategy(cfg), resolve_output_mode(cfg)
 
@@ -230,6 +236,28 @@ def resolve_sampling_spec(
     return _resolve_sampling_spec_from_sampling_params(sampling_config, tiling=tiling)
 
 
+def _drop_null_labels(
+    pixel_mapping: dict[str, Any],
+    *companions: dict[str, Any] | None,
+) -> tuple[dict[str, Any], list[dict[str, Any] | None]]:
+    """Drop labels removed via the null-to-drop idiom (pixel value set to null) and filter the
+    companion mappings (min_coverage, colors) to the surviving labels.
+
+    Configs are deep-merged over the default ``{background:0, tissue:1}`` mapping, so shadowing
+    a default value isn't enough to remove a default label — e.g. reusing value ``1`` for a new
+    class collides with the default ``tissue:1``. Nulling a label's pixel value removes it
+    entirely (mirroring how ``min_coverage.<label>: null`` drops a class from sampling), and the
+    label is also stripped from the companion mappings so the cross-mapping checks stay coherent.
+    """
+    removed = {name for name, value in pixel_mapping.items() if value is None}
+    kept = {name: value for name, value in pixel_mapping.items() if value is not None}
+    filtered = [
+        None if m is None else {k: v for k, v in m.items() if k not in removed}
+        for m in companions
+    ]
+    return kept, filtered
+
+
 def _resolve_sampling_spec_from_masks(masks_cfg: Any, *, tiling: TilingConfig) -> SamplingSpec:
     pixel_mapping = _merge_sampling_mapping(
         getattr(masks_cfg, "pixel_mapping", None),
@@ -243,6 +271,13 @@ def _resolve_sampling_spec_from_masks(masks_cfg: Any, *, tiling: TilingConfig) -
         raise ValueError("masks.pixel_mapping is required")
     if min_coverage is None:
         raise ValueError("masks.min_coverage is required")
+    colors = _merge_sampling_mapping(
+        getattr(masks_cfg, "colors", None),
+        field_name="colors",
+    )
+    pixel_mapping, (min_coverage, colors) = _drop_null_labels(
+        pixel_mapping, min_coverage, colors
+    )
     validate_pixel_mapping(pixel_mapping)
     missing_coverage_labels = sorted(set(min_coverage.keys()) - set(pixel_mapping.keys()))
     if missing_coverage_labels:
@@ -250,10 +285,6 @@ def _resolve_sampling_spec_from_masks(masks_cfg: Any, *, tiling: TilingConfig) -
             "masks.min_coverage references unknown labels: "
             + ", ".join(missing_coverage_labels)
         )
-    colors = _merge_sampling_mapping(
-        getattr(masks_cfg, "colors", None),
-        field_name="colors",
-    )
     if colors is not None:
         validate_color_mapping(pixel_mapping=pixel_mapping, color_mapping=colors)
 
@@ -288,6 +319,13 @@ def _resolve_sampling_spec_from_sampling_params(
         raise ValueError(
             "sampling tissue_percentage is required when sampling config is provided"
         )
+    color_mapping = _merge_sampling_mapping(
+        getattr(sampling_config, "color_mapping", None),
+        field_name="color_mapping",
+    )
+    pixel_mapping, (tissue_percentage, color_mapping) = _drop_null_labels(
+        pixel_mapping, tissue_percentage, color_mapping
+    )
     validate_pixel_mapping(pixel_mapping)
     missing_threshold_labels = sorted(
         set(tissue_percentage.keys()) - set(pixel_mapping.keys())
@@ -297,10 +335,6 @@ def _resolve_sampling_spec_from_sampling_params(
             "sampling tissue_percentage references unknown labels: "
             + ", ".join(missing_threshold_labels)
         )
-    color_mapping = _merge_sampling_mapping(
-        getattr(sampling_config, "color_mapping", None),
-        field_name="color_mapping",
-    )
     if color_mapping is not None:
         validate_color_mapping(
             pixel_mapping=pixel_mapping,

--- a/hs2p/configs/resolvers.py
+++ b/hs2p/configs/resolvers.py
@@ -142,9 +142,22 @@ def validate_pixel_mapping(pixel_mapping: dict[str, int]) -> None:
     must map to a distinct, non-negative integer within the supported ``uint16`` range so the
     read path can split classes by exact value without collisions or silent wrapping (see
     :func:`hs2p.tiling.mask._as_discrete_label_array`).
+
+    Label *names* become on-disk path components (``output_dir/tiles/<label>/...`` for
+    per-annotation artifacts), so they must be safe single path components — no separators,
+    no ``.``/``..`` — to keep artifacts inside the run's output directory.
     """
     seen: dict[int, str] = {}
     for annotation, value in pixel_mapping.items():
+        if (
+            not annotation
+            or annotation in {".", ".."}
+            or any(ch in annotation for ch in ("/", "\\", "\x00"))
+        ):
+            raise ValueError(
+                f"pixel_mapping label {annotation!r} must be a safe path component "
+                "(non-empty, no '/'\\ separators, not '.' or '..')"
+            )
         if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
             raise ValueError(
                 f"pixel_mapping['{annotation}'] must be an integer label value, got {value!r}"

--- a/hs2p/configs/resolvers.py
+++ b/hs2p/configs/resolvers.py
@@ -95,6 +95,34 @@ def _merge_sampling_mapping(
     return merged
 
 
+def validate_pixel_mapping(pixel_mapping: dict[str, int]) -> None:
+    """Validate the annotation ``pixel_mapping`` up front, before any slide is opened.
+
+    ``pixel_mapping`` is the user's own label vocabulary — no name is reserved. Each label
+    must map to a distinct, non-negative integer within the supported ``uint16`` range so the
+    read path can split classes by exact value without collisions or silent wrapping (see
+    :func:`hs2p.tiling.mask._as_discrete_label_array`).
+    """
+    seen: dict[int, str] = {}
+    for annotation, value in pixel_mapping.items():
+        if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+            raise ValueError(
+                f"pixel_mapping['{annotation}'] must be an integer label value, got {value!r}"
+            )
+        ivalue = int(value)
+        if ivalue < 0 or ivalue > 65535:
+            raise ValueError(
+                f"pixel_mapping['{annotation}']={ivalue} is outside the supported "
+                "label range [0, 65535]"
+            )
+        if ivalue in seen:
+            raise ValueError(
+                "pixel_mapping values must be unique: "
+                f"'{annotation}' and '{seen[ivalue]}' both map to {ivalue}"
+            )
+        seen[ivalue] = annotation
+
+
 def validate_color_mapping(
     *,
     pixel_mapping: dict[str, int],
@@ -162,8 +190,7 @@ def _resolve_sampling_spec_from_masks(masks_cfg: Any, *, tiling: TilingConfig) -
         raise ValueError("masks.pixel_mapping is required")
     if min_coverage is None:
         raise ValueError("masks.min_coverage is required")
-    if "background" not in pixel_mapping:
-        raise ValueError("masks.pixel_mapping must include a 'background' label")
+    validate_pixel_mapping(pixel_mapping)
     missing_coverage_labels = sorted(set(min_coverage.keys()) - set(pixel_mapping.keys()))
     if missing_coverage_labels:
         raise ValueError(
@@ -184,7 +211,7 @@ def _resolve_sampling_spec_from_masks(masks_cfg: Any, *, tiling: TilingConfig) -
         active_annotations=tuple(
             annotation
             for annotation, pct in min_coverage.items()
-            if annotation in pixel_mapping and pct is not None and annotation != "background"
+            if annotation in pixel_mapping and pct is not None
         ),
     )
 
@@ -208,8 +235,7 @@ def _resolve_sampling_spec_from_sampling_params(
         raise ValueError(
             "sampling tissue_percentage is required when sampling config is provided"
         )
-    if "background" not in pixel_mapping:
-        raise ValueError("sampling pixel_mapping must include a 'background' label")
+    validate_pixel_mapping(pixel_mapping)
     missing_threshold_labels = sorted(
         set(tissue_percentage.keys()) - set(pixel_mapping.keys())
     )
@@ -235,6 +261,6 @@ def _resolve_sampling_spec_from_sampling_params(
         active_annotations=tuple(
             annotation
             for annotation, pct in tissue_percentage.items()
-            if annotation in pixel_mapping and pct is not None and annotation != "background"
+            if annotation in pixel_mapping and pct is not None
         ),
     )

--- a/hs2p/preprocessing.py
+++ b/hs2p/preprocessing.py
@@ -1,7 +1,7 @@
 """Reusable low-level preprocessing primitives shared with downstream projects."""
 
 from hs2p.tiling.contours import _normalize_level_downsamples, detect_contours
-from hs2p.tiling.coverage import compute_tile_coverage
+from hs2p.tiling.coverage import compute_tile_coverage, summarize_annotation_coverage
 from hs2p.tiling.generate import (
     _build_contour_tissue_mask,
     _tiles_for_contour,
@@ -29,8 +29,10 @@ from hs2p.tiling.io import (
     validate_tiling_result_provenance,
 )
 from hs2p.tiling.mask import (
+    load_annotation_label_mask,
     load_precomputed_tissue_mask,
     prepare_sam2_thumbnail,
+    resolve_annotation_masks,
     resolve_tissue_mask,
 )
 from hs2p.tiling.result import (
@@ -57,11 +59,15 @@ __all__ = [
     "ResolvedAnnotationMasks",
     "Sam2Thumbnail",
     "canonicalize_tiling_result",
+    "compute_tile_coverage",
     "detect_contours",
     "generate_tiles",
+    "load_annotation_label_mask",
     "load_precomputed_tissue_mask",
     "prepare_sam2_thumbnail",
+    "resolve_annotation_masks",
     "resolve_tissue_mask",
+    "summarize_annotation_coverage",
     "build_tiling_result_from_mask",
     "build_per_annotation_tiling_results",
     "normalize_artifact_path",

--- a/hs2p/tiling/coverage.py
+++ b/hs2p/tiling/coverage.py
@@ -54,4 +54,64 @@ def compute_tile_coverage(
     return np.clip((tissue_sum / tile_area).astype(np.float32), 0.0, 1.0)
 
 
-__all__ = ["compute_tile_coverage"]
+def summarize_annotation_coverage(
+    *,
+    slide,
+    resolved_masks,
+    min_coverage: dict[str, float | None] | None,
+    requested_tile_size_px: int,
+    requested_spacing_um: float,
+    overlap: float = 0.0,
+) -> dict[str, dict[str, float | int | None]]:
+    """Per-class annotation coverage summary at the resolved ``seg_downsample``.
+
+    Returns ``{class_name: {"area_mm2", "frac", "est_tiles"}}`` where:
+
+    - ``area_mm2`` — class foreground area, from the seg-space pixel count scaled by the
+      seg-level spacing (``(seg_spacing_um / 1000) ** 2`` mm² per pixel).
+    - ``frac`` — class area divided by the total annotated (non-background) area, i.e. the
+      class's share among annotations (sums to 1 across classes).
+    - ``est_tiles`` — number of non-overlapping tile footprints whose class coverage is at
+      least ``min_coverage[class]`` (``None`` when no threshold is given). This is an
+      *estimate*: it reuses :func:`compute_tile_coverage` over a regular level-0 grid and
+      deliberately ignores tissue filtering and tile overlap.
+
+    Reuses hs2p's existing coverage primitive (the controllable ``seg_downsample`` is the
+    precision/speed knob) rather than re-scanning the mask.
+    """
+    seg_spacing_um = float(resolved_masks.seg_spacing_um)
+    mm2_per_pixel = (seg_spacing_um / 1000.0) ** 2
+    areas_px = {
+        name: float(np.count_nonzero(mask)) for name, mask in resolved_masks.masks.items()
+    }
+    total_annotated = sum(areas_px.values())
+
+    base_spacing_um = float(slide.spacing)
+    tile_size_lv0 = max(1, round(requested_tile_size_px * requested_spacing_um / base_spacing_um))
+    step = max(1, round(tile_size_lv0 * (1.0 - overlap)))
+    slide_w, slide_h = int(slide.dimensions[0]), int(slide.dimensions[1])
+    xs = np.arange(0, max(1, slide_w), step, dtype=np.int64)
+    ys = np.arange(0, max(1, slide_h), step, dtype=np.int64)
+    grid_x, grid_y = np.meshgrid(xs, ys)
+    candidates = np.column_stack((grid_x.ravel(), grid_y.ravel())).astype(np.int64)
+
+    summary: dict[str, dict[str, float | int | None]] = {}
+    for name, binary_mask in resolved_masks.masks.items():
+        area_px = areas_px[name]
+        threshold = None if min_coverage is None else min_coverage.get(name)
+        if threshold is None:
+            est_tiles: int | None = None
+        else:
+            coverage = compute_tile_coverage(
+                candidates, binary_mask, tile_size_lv0, (slide_w, slide_h)
+            )
+            est_tiles = int(np.count_nonzero(coverage >= float(threshold)))
+        summary[name] = {
+            "area_mm2": area_px * mm2_per_pixel,
+            "frac": (area_px / total_annotated) if total_annotated > 0 else 0.0,
+            "est_tiles": est_tiles,
+        }
+    return summary
+
+
+__all__ = ["compute_tile_coverage", "summarize_annotation_coverage"]

--- a/hs2p/tiling/coverage.py
+++ b/hs2p/tiling/coverage.py
@@ -69,22 +69,31 @@ def summarize_annotation_coverage(
 
     - ``area_mm2`` — class foreground area, from the seg-space pixel count scaled by the
       seg-level spacing (``(seg_spacing_um / 1000) ** 2`` mm² per pixel).
-    - ``frac`` — class area divided by the total annotated (non-background) area, i.e. the
-      class's share among annotations (sums to 1 across classes).
+    - ``frac`` — class area divided by the total area of the classes of interest, i.e. the
+      class's share among the classes given a ``min_coverage`` threshold (sums to 1 across
+      those classes). ``None`` for a class without a threshold. No label name is special:
+      ``min_coverage`` is the only signal for "which classes matter", so a declared-but-
+      unthresholded label (e.g. the value reserved for unannotated pixels) is excluded from
+      both the numerator set and the denominator.
     - ``est_tiles`` — number of non-overlapping tile footprints whose class coverage is at
       least ``min_coverage[class]`` (``None`` when no threshold is given). This is an
       *estimate*: it reuses :func:`compute_tile_coverage` over a regular level-0 grid and
       deliberately ignores tissue filtering and tile overlap.
 
-    Reuses hs2p's existing coverage primitive (the controllable ``seg_downsample`` is the
-    precision/speed knob) rather than re-scanning the mask.
+    ``area_mm2`` is reported for every declared class; ``frac``/``est_tiles`` only for the
+    thresholded classes. Reuses hs2p's existing coverage primitive (the controllable
+    ``seg_downsample`` is the precision/speed knob) rather than re-scanning the mask.
     """
     seg_spacing_um = float(resolved_masks.seg_spacing_um)
     mm2_per_pixel = (seg_spacing_um / 1000.0) ** 2
     areas_px = {
         name: float(np.count_nonzero(mask)) for name, mask in resolved_masks.masks.items()
     }
-    total_annotated = sum(areas_px.values())
+    total_of_interest = sum(
+        area
+        for name, area in areas_px.items()
+        if min_coverage is not None and min_coverage.get(name) is not None
+    )
 
     base_spacing_um = float(slide.spacing)
     tile_size_lv0 = max(1, round(requested_tile_size_px * requested_spacing_um / base_spacing_um))
@@ -101,14 +110,16 @@ def summarize_annotation_coverage(
         threshold = None if min_coverage is None else min_coverage.get(name)
         if threshold is None:
             est_tiles: int | None = None
+            frac: float | None = None
         else:
             coverage = compute_tile_coverage(
                 candidates, binary_mask, tile_size_lv0, (slide_w, slide_h)
             )
             est_tiles = int(np.count_nonzero(coverage >= float(threshold)))
+            frac = (area_px / total_of_interest) if total_of_interest > 0 else 0.0
         summary[name] = {
             "area_mm2": area_px * mm2_per_pixel,
-            "frac": (area_px / total_annotated) if total_annotated > 0 else 0.0,
+            "frac": frac,
             "est_tiles": est_tiles,
         }
     return summary

--- a/hs2p/tiling/mask.py
+++ b/hs2p/tiling/mask.py
@@ -378,19 +378,32 @@ def load_annotation_label_mask(
 
     Robustness guard: some backends mis-decode intermediate levels of a compressed
     single-channel (minisblack) pyramid and return an all-background level (observed with
-    cucim + LZW/deflate masks, where openslide decodes the same level correctly). When the
-    primary read is entirely background, we retry via openslide and prefer that result if it
-    recovers labels — costless when the primary read already carries labels, and safe for
-    genuinely-empty masks (openslide would agree).
+    cucim + LZW/deflate masks, where openslide decodes the same level correctly). We retry via
+    openslide and prefer that result when it recovers labels — costless when the primary read
+    already carries labels, and safe for genuinely-empty masks (openslide would agree).
+
+    The degenerate read shows up two ways depending on the label vocabulary: if the background
+    value is declared, the all-background level reads as a valid (empty) mask; if it is not
+    (e.g. ``{tumor: 1, stroma: 2}`` with no ``0``), the discreteness guard *rejects* the
+    all-zero level and raises. Both must trigger the openslide retry, so the primary read is
+    guarded and its error only surfaces if openslide fails to recover.
     """
-    raw_mask, mask_level, mask_spacing_um = _read_label_mask_at_seg(
-        mask_path=mask_path,
-        slide=slide,
-        seg_level=seg_level,
-        valid_values=valid_values,
-        backend=slide.backend_name,
-    )
-    if not raw_mask.any() and str(getattr(slide, "backend_name", "")).lower() != "openslide":
+    backend_name = str(getattr(slide, "backend_name", "")).lower()
+    primary_error: Exception | None = None
+    raw_mask = mask_level = mask_spacing_um = None
+    try:
+        raw_mask, mask_level, mask_spacing_um = _read_label_mask_at_seg(
+            mask_path=mask_path,
+            slide=slide,
+            seg_level=seg_level,
+            valid_values=valid_values,
+            backend=slide.backend_name,
+        )
+    except Exception as exc:
+        primary_error = exc
+
+    degenerate = primary_error is not None or not raw_mask.any()
+    if degenerate and backend_name != "openslide":
         try:
             fallback, fb_level, fb_spacing = _read_label_mask_at_seg(
                 mask_path=mask_path,
@@ -403,6 +416,9 @@ def load_annotation_label_mask(
             fallback = None
         if fallback is not None and fallback.any():
             return fallback, fb_level, fb_spacing
+
+    if primary_error is not None:
+        raise primary_error
     return raw_mask, mask_level, mask_spacing_um
 
 

--- a/hs2p/tiling/mask.py
+++ b/hs2p/tiling/mask.py
@@ -9,7 +9,7 @@ from PIL import Image
 from hs2p.configs import SegmentationConfig
 from hs2p.segmentation import segment_tissue_image
 from hs2p.tiling.contours import _normalize_level_downsamples
-from hs2p.tiling.result import ResolvedTissueMask, Sam2Thumbnail
+from hs2p.tiling.result import ResolvedAnnotationMasks, ResolvedTissueMask, Sam2Thumbnail
 from hs2p.wsi.reader import open_slide, select_level, select_level_for_downsample
 
 DEFAULT_SAM2_THUMBNAIL_SPACING_UM = 8.0
@@ -40,17 +40,28 @@ def _read_exact_tiff_mask_level(mask_path: str | Path, *, mask_level: int) -> np
         return np.asarray(image)
 
 
-def _read_mask_level(
+def _is_label_subset(mask: np.ndarray, *, valid_values: set[int]) -> bool:
+    values = {int(value) for value in np.unique(mask.astype(np.int64, copy=False)).tolist()}
+    return values <= valid_values
+
+
+def _read_discrete_mask_level(
     *,
     mask_path: str | Path,
     mask_slide,
     mask_level: int,
-    tissue_value: int,
+    is_discrete,
+    label: str,
 ) -> np.ndarray:
+    """Read a mask level, preferring the backend read but falling back to an exact TIFF read
+    when the backend's (possibly interpolated) downsampled level is not label-discrete.
+
+    ``is_discrete`` is the predicate that decides acceptability — a single-tissue-value check
+    for tissue masks, or a class-value-subset check for multi-class annotation masks.
+    """
     mask_size = mask_slide.level_dimensions[mask_level]
-    backend_mask = mask_slide.read_region((0, 0), mask_level, mask_size)
-    backend_mask = _reduce_mask_channels(backend_mask)
-    if _is_discrete_binary_mask(backend_mask, tissue_value=tissue_value):
+    backend_mask = _reduce_mask_channels(mask_slide.read_region((0, 0), mask_level, mask_size))
+    if is_discrete(backend_mask):
         return backend_mask.astype(np.uint8, copy=False)
 
     suffix = Path(mask_path).suffix.lower()
@@ -58,12 +69,28 @@ def _read_mask_level(
         exact_mask = _reduce_mask_channels(
             _read_exact_tiff_mask_level(mask_path, mask_level=mask_level)
         )
-        if _is_discrete_binary_mask(exact_mask, tissue_value=tissue_value):
+        if is_discrete(exact_mask):
             return exact_mask.astype(np.uint8, copy=False)
     values = np.unique(backend_mask.astype(np.int64, copy=False))
     raise ValueError(
-        "Precomputed tissue mask read produced non-discrete labels "
+        f"{label} read produced non-discrete labels "
         f"at level {mask_level}: {values.tolist()[:16]}"
+    )
+
+
+def _read_mask_level(
+    *,
+    mask_path: str | Path,
+    mask_slide,
+    mask_level: int,
+    tissue_value: int,
+) -> np.ndarray:
+    return _read_discrete_mask_level(
+        mask_path=mask_path,
+        mask_slide=mask_slide,
+        mask_level=mask_level,
+        is_discrete=lambda mask: _is_discrete_binary_mask(mask, tissue_value=tissue_value),
+        label="Precomputed tissue mask",
     )
 
 
@@ -271,8 +298,145 @@ def resolve_tissue_mask(
     )
 
 
+def _read_label_mask_at_seg(
+    *,
+    mask_path: str | Path,
+    slide,
+    seg_level: int,
+    valid_values: set[int],
+    backend: str,
+) -> tuple[np.ndarray, int, float]:
+    """Read the label raster at the mask level nearest the slide's ``seg_level`` spacing,
+    nearest-resampled to the seg grid, using the requested ``backend``."""
+    mask_slide = open_slide(mask_path, backend=backend)
+    try:
+        seg_size = slide.level_dimensions[seg_level]
+        seg_spacing_um = float(slide.spacing) * float(
+            _normalize_level_downsamples(slide.level_downsamples)[seg_level]
+        )
+        mask_level, mask_spacing_um = _select_mask_level(
+            mask_slide=mask_slide,
+            requested_spacing_um=seg_spacing_um,
+        )
+        raw_mask = _read_discrete_mask_level(
+            mask_path=mask_path,
+            mask_slide=mask_slide,
+            mask_level=mask_level,
+            is_discrete=lambda mask: _is_label_subset(mask, valid_values=valid_values),
+            label="Annotation mask",
+        )
+    finally:
+        mask_slide.close()
+
+    if raw_mask.shape[:2] != (int(seg_size[1]), int(seg_size[0])):
+        raw_mask = cv2.resize(
+            raw_mask.astype(np.uint8, copy=False),
+            (int(seg_size[0]), int(seg_size[1])),
+            interpolation=cv2.INTER_NEAREST,
+        )
+    return raw_mask.astype(np.uint8, copy=False), mask_level, mask_spacing_um
+
+
+def load_annotation_label_mask(
+    *,
+    mask_path: str | Path,
+    slide,
+    seg_level: int,
+    valid_values: set[int],
+) -> tuple[np.ndarray, int, float]:
+    """Read a multi-class annotation label raster resampled to the slide's ``seg_level`` grid.
+
+    Mirrors :func:`load_precomputed_tissue_mask` but preserves every class index (no
+    binarization) and validates against the annotation pixel-value set rather than a single
+    tissue value. Resampling is nearest-neighbor — any averaging would invent class indices.
+
+    Robustness guard: some backends mis-decode intermediate levels of a compressed
+    single-channel (minisblack) pyramid and return an all-background level (observed with
+    cucim + LZW/deflate masks, where openslide decodes the same level correctly). When the
+    primary read is entirely background, we retry via openslide and prefer that result if it
+    recovers labels — costless when the primary read already carries labels, and safe for
+    genuinely-empty masks (openslide would agree).
+    """
+    raw_mask, mask_level, mask_spacing_um = _read_label_mask_at_seg(
+        mask_path=mask_path,
+        slide=slide,
+        seg_level=seg_level,
+        valid_values=valid_values,
+        backend=slide.backend_name,
+    )
+    if not raw_mask.any() and str(getattr(slide, "backend_name", "")).lower() != "openslide":
+        try:
+            fallback, fb_level, fb_spacing = _read_label_mask_at_seg(
+                mask_path=mask_path,
+                slide=slide,
+                seg_level=seg_level,
+                valid_values=valid_values,
+                backend="openslide",
+            )
+        except Exception:
+            fallback = None
+        if fallback is not None and fallback.any():
+            return fallback, fb_level, fb_spacing
+    return raw_mask, mask_level, mask_spacing_um
+
+
+def resolve_annotation_masks(
+    *,
+    slide,
+    mask_path: str | Path,
+    pixel_mapping: dict[str, int],
+    seg_downsample: int = 64,
+    tissue_method: str = "precomputed_mask",
+) -> ResolvedAnnotationMasks:
+    """Read an annotation mask into one binary mask per (non-background) class at ``seg_downsample``.
+
+    The multi-label producer that ``build_per_annotation_tiling_results`` consumes but that
+    was missing from the codebase — the annotation counterpart of
+    :func:`resolve_tissue_mask`'s precomputed path. ``pixel_mapping`` maps class name to the
+    integer pixel value in the mask and must include a ``background`` entry; one binary mask
+    (255 foreground / 0 background) is produced per non-background class.
+    """
+    if mask_path is None:
+        raise ValueError("resolve_annotation_masks requires a mask_path")
+    if "background" not in pixel_mapping:
+        raise ValueError("pixel_mapping must include a 'background' label")
+
+    normalized_downsamples = _normalize_level_downsamples(slide.level_downsamples)
+    seg_level = select_level_for_downsample(
+        float(seg_downsample),
+        [(float(ds), float(ds)) for ds in normalized_downsamples],
+    )
+    seg_spacing_um = float(slide.spacing) * float(normalized_downsamples[seg_level])
+    valid_values = {int(value) for value in pixel_mapping.values()}
+    raw_mask, mask_level, mask_spacing_um = load_annotation_label_mask(
+        mask_path=mask_path,
+        slide=slide,
+        seg_level=seg_level,
+        valid_values=valid_values,
+    )
+    masks = {
+        name: np.where(raw_mask == int(value), np.uint8(255), np.uint8(0)).astype(np.uint8)
+        for name, value in pixel_mapping.items()
+        if name != "background"
+    }
+    return ResolvedAnnotationMasks(
+        masks=masks,
+        tissue_method=tissue_method,
+        requested_seg_downsample=int(seg_downsample),
+        seg_downsample=max(1, int(round(seg_spacing_um / float(slide.spacing)))),
+        seg_level=seg_level,
+        seg_spacing_um=seg_spacing_um,
+        pixel_mapping=dict(pixel_mapping),
+        mask_path=mask_path,
+        mask_level=mask_level,
+        mask_spacing_um=mask_spacing_um,
+    )
+
+
 __all__ = [
+    "load_annotation_label_mask",
     "load_precomputed_tissue_mask",
     "prepare_sam2_thumbnail",
+    "resolve_annotation_masks",
     "resolve_tissue_mask",
 ]

--- a/hs2p/tiling/mask.py
+++ b/hs2p/tiling/mask.py
@@ -22,6 +22,32 @@ def _reduce_mask_channels(mask: np.ndarray) -> np.ndarray:
     return np.asarray(mask)
 
 
+def _as_discrete_label_array(mask: np.ndarray) -> np.ndarray:
+    """Return ``mask`` as the smallest cv2-resize-safe unsigned integer dtype that
+    preserves every label value (``uint8`` or ``uint16``).
+
+    Discrete masks must never be silently narrowed: downcasting a validated ``uint16``
+    label raster to ``uint8`` would wrap any value above 255 modulo 256, making a class
+    vanish or merge into the class that owns the wrapped value. Labels are non-negative
+    class ids, so we reject negatives and values past the supported ``uint16`` range
+    rather than corrupting them.
+    """
+    arr = np.asarray(mask)
+    if arr.size == 0:
+        return arr.astype(np.uint8, copy=False)
+    min_value = int(arr.min())
+    max_value = int(arr.max())
+    if min_value < 0:
+        raise ValueError(f"Mask contains negative label value {min_value}")
+    if max_value <= np.iinfo(np.uint8).max:
+        return arr.astype(np.uint8, copy=False)
+    if max_value <= np.iinfo(np.uint16).max:
+        return arr.astype(np.uint16, copy=False)
+    raise ValueError(
+        f"Mask label value {max_value} exceeds the supported uint16 range"
+    )
+
+
 def _is_discrete_binary_mask(mask: np.ndarray, *, tissue_value: int) -> bool:
     values = np.unique(mask.astype(np.int64, copy=False))
     non_tissue = [int(value) for value in values.tolist() if int(value) != tissue_value]
@@ -62,7 +88,7 @@ def _read_discrete_mask_level(
     mask_size = mask_slide.level_dimensions[mask_level]
     backend_mask = _reduce_mask_channels(mask_slide.read_region((0, 0), mask_level, mask_size))
     if is_discrete(backend_mask):
-        return backend_mask.astype(np.uint8, copy=False)
+        return _as_discrete_label_array(backend_mask)
 
     suffix = Path(mask_path).suffix.lower()
     if suffix in {".tif", ".tiff"}:
@@ -70,7 +96,7 @@ def _read_discrete_mask_level(
             _read_exact_tiff_mask_level(mask_path, mask_level=mask_level)
         )
         if is_discrete(exact_mask):
-            return exact_mask.astype(np.uint8, copy=False)
+            return _as_discrete_label_array(exact_mask)
     values = np.unique(backend_mask.astype(np.int64, copy=False))
     raise ValueError(
         f"{label} read produced non-discrete labels "
@@ -139,7 +165,7 @@ def load_precomputed_tissue_mask(
 
     if raw_mask.shape[:2] != (int(seg_size[1]), int(seg_size[0])):
         raw_mask = cv2.resize(
-            raw_mask.astype(np.uint8, copy=False),
+            _as_discrete_label_array(raw_mask),
             (int(seg_size[0]), int(seg_size[1])),
             interpolation=cv2.INTER_NEAREST,
         )
@@ -330,11 +356,11 @@ def _read_label_mask_at_seg(
 
     if raw_mask.shape[:2] != (int(seg_size[1]), int(seg_size[0])):
         raw_mask = cv2.resize(
-            raw_mask.astype(np.uint8, copy=False),
+            _as_discrete_label_array(raw_mask),
             (int(seg_size[0]), int(seg_size[1])),
             interpolation=cv2.INTER_NEAREST,
         )
-    return raw_mask.astype(np.uint8, copy=False), mask_level, mask_spacing_um
+    return _as_discrete_label_array(raw_mask), mask_level, mask_spacing_um
 
 
 def load_annotation_label_mask(
@@ -388,18 +414,23 @@ def resolve_annotation_masks(
     seg_downsample: int = 64,
     tissue_method: str = "precomputed_mask",
 ) -> ResolvedAnnotationMasks:
-    """Read an annotation mask into one binary mask per (non-background) class at ``seg_downsample``.
+    """Read an annotation mask into one binary mask per declared label at ``seg_downsample``.
 
     The multi-label producer that ``build_per_annotation_tiling_results`` consumes but that
     was missing from the codebase — the annotation counterpart of
     :func:`resolve_tissue_mask`'s precomputed path. ``pixel_mapping`` maps class name to the
-    integer pixel value in the mask and must include a ``background`` entry; one binary mask
-    (255 foreground / 0 background) is produced per non-background class.
+    integer pixel value in the mask; one binary mask (255 foreground / 0 background) is
+    produced for **every** entry — no label name is special. ``pixel_mapping`` is the user's
+    own vocabulary; *which* of these classes get sampled is decided downstream by the sampling
+    spec (``min_coverage`` thresholds), not here.
+
+    There is no reserved ``background`` label: every pixel value present in the raster must be
+    declared (the read-time discreteness guard rejects undeclared values), so if the raster
+    reserves a value for unannotated pixels, declare it like any other class — just give it no
+    coverage threshold and it will never be sampled.
     """
     if mask_path is None:
         raise ValueError("resolve_annotation_masks requires a mask_path")
-    if "background" not in pixel_mapping:
-        raise ValueError("pixel_mapping must include a 'background' label")
 
     normalized_downsamples = _normalize_level_downsamples(slide.level_downsamples)
     seg_level = select_level_for_downsample(
@@ -417,7 +448,6 @@ def resolve_annotation_masks(
     masks = {
         name: np.where(raw_mask == int(value), np.uint8(255), np.uint8(0)).astype(np.uint8)
         for name, value in pixel_mapping.items()
-        if name != "background"
     }
     return ResolvedAnnotationMasks(
         masks=masks,

--- a/hs2p/tiling/mask.py
+++ b/hs2p/tiling/mask.py
@@ -403,9 +403,10 @@ def load_annotation_label_mask(
         primary_error = exc
 
     degenerate = primary_error is not None or not raw_mask.any()
+    fallback = None
     if degenerate and backend_name != "openslide":
         try:
-            fallback, fb_level, fb_spacing = _read_label_mask_at_seg(
+            fallback = _read_label_mask_at_seg(
                 mask_path=mask_path,
                 slide=slide,
                 seg_level=seg_level,
@@ -414,8 +415,15 @@ def load_annotation_label_mask(
             )
         except Exception:
             fallback = None
-        if fallback is not None and fallback.any():
-            return fallback, fb_level, fb_spacing
+    if fallback is not None:
+        fb_mask, fb_level, fb_spacing = fallback
+        # When the primary read *raised*, any validated fallback is acceptable — including a
+        # legitimately all-zero mask (a genuinely empty raster, or a label mapped to 0 now
+        # that no value is reserved). The ``.any()`` gate applies only to the all-background
+        # *successful*-primary recovery heuristic, where we prefer openslide solely when it
+        # actually recovers labels rather than swapping one empty read for another.
+        if primary_error is not None or fb_mask.any():
+            return fb_mask, fb_level, fb_spacing
 
     if primary_error is not None:
         raise primary_error

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -16,11 +16,16 @@ import pandas as pd
 from hs2p.configs import FilterConfig, PreviewConfig, SegmentationConfig, TilingConfig
 from hs2p.progress import emit_progress, emit_progress_log
 from hs2p.tiling.result import ResolvedTissueMask, TilingResult
-from hs2p.tiling.single import build_tiling_result_from_mask, preprocess_slide
+from hs2p.tiling.single import (
+    build_tiling_result_from_mask,
+    preprocess_slide,
+    preprocess_slide_per_annotation,
+)
 from hs2p.tiling.tar import _annotation_tar_stem, _needs_pixel_filtering, extract_tiles_to_tar
 from hs2p.wsi import (
     CoordinateOutputMode,
     CoordinateSelectionStrategy,
+    SamplingSpec,
     normalize_tissue_mask,
     save_overlay_preview,
     write_coordinate_preview,
@@ -242,6 +247,57 @@ def _compute_tiling_result(
         slide.close()
 
 
+def _run_per_annotation(
+    *,
+    whole_slide: SlideSpec,
+    tiling: TilingConfig,
+    filtering: FilterConfig,
+    sampling: SamplingSpec,
+    selection_strategy: str,
+    output_mode: str,
+    seg_downsample: int,
+    num_workers: int,
+) -> "dict[str, TilingResult]":
+    """Shared annotation-sampling compute, called identically by ``tile_slide`` and the
+    ``tile_slides`` worker so the two paths never diverge. Resolves the annotation mask and
+    samples one :class:`TilingResult` per active annotation."""
+    if whole_slide.mask_path is None:
+        raise ValueError(
+            "annotation sampling requires whole_slide.mask_path (the annotation mask)"
+        )
+    return preprocess_slide_per_annotation(
+        image_path=whole_slide.image_path,
+        mask_path=whole_slide.mask_path,
+        pixel_mapping=sampling.pixel_mapping,
+        sampling_spec=sampling,
+        selection_strategy=selection_strategy,
+        sample_id=whole_slide.sample_id,
+        backend=tiling.backend,
+        spacing_override=whole_slide.spacing_at_level_0,
+        requested_tile_size_px=tiling.requested_tile_size_px,
+        requested_spacing_um=tiling.requested_spacing_um,
+        overlap=tiling.overlap,
+        seg_downsample=seg_downsample,
+        tolerance=tiling.tolerance,
+        ref_tile_size_px=filtering.ref_tile_size,
+        a_t=filtering.a_t,
+        a_h=filtering.a_h,
+        filter_white=filtering.filter_white,
+        filter_black=filtering.filter_black,
+        white_threshold=filtering.white_threshold,
+        black_threshold=filtering.black_threshold,
+        fraction_threshold=filtering.fraction_threshold,
+        filter_grayspace=filtering.filter_grayspace,
+        grayspace_saturation_threshold=filtering.grayspace_saturation_threshold,
+        grayspace_fraction_threshold=filtering.grayspace_fraction_threshold,
+        filter_blur=filtering.filter_blur,
+        blur_threshold=filtering.blur_threshold,
+        qc_spacing_um=filtering.qc_spacing_um,
+        num_workers=num_workers,
+        output_mode=output_mode,
+    )
+
+
 def tile_slide(
     whole_slide: SlideSpec,
     *,
@@ -249,7 +305,13 @@ def tile_slide(
     segmentation: SegmentationConfig | None = None,
     filtering: FilterConfig = FilterConfig(),
     num_workers: int = 1,
-) -> TilingResult:
+    sampling: SamplingSpec | None = None,
+    selection_strategy: str | None = None,
+    output_mode: str | None = None,
+) -> "TilingResult | dict[str, TilingResult]":
+    """Tile a single slide. With ``sampling`` provided, performs annotation-aware sampling
+    and returns one :class:`TilingResult` per active annotation (``{annotation: result}``);
+    otherwise tiles tissue and returns a single :class:`TilingResult`."""
     backend_selection = resolve_backend(
         tiling.requested_backend,
         wsi_path=whole_slide.image_path,
@@ -271,6 +333,17 @@ def tile_slide(
         whole_slide=whole_slide,
         segmentation=segmentation,
     )
+    if sampling is not None:
+        return _run_per_annotation(
+            whole_slide=whole_slide,
+            tiling=effective_tiling,
+            filtering=filtering,
+            sampling=sampling,
+            selection_strategy=selection_strategy or CoordinateSelectionStrategy.JOINT_SAMPLING,
+            output_mode=output_mode or CoordinateOutputMode.PER_ANNOTATION,
+            seg_downsample=effective_segmentation.downsample,
+            num_workers=num_workers,
+        )
     return preprocess_slide(
         image_path=whole_slide.image_path,
         sample_id=whole_slide.sample_id,
@@ -391,6 +464,9 @@ class _ComputeRequest:
     gpu_decode: bool = False
     include_result: bool = False
     save_tiles: bool = False
+    sampling: SamplingSpec | None = None
+    sampling_selection_strategy: str | None = None
+    sampling_output_mode: str | None = None
 
 
 @dataclass(frozen=True)
@@ -405,6 +481,9 @@ class _ComputeResponse:
     mask_preview_path: Path | None = None
     error: str | None = None
     traceback_text: str | None = None
+    # Annotation sampling produces one artifact per active annotation; the first lands in
+    # ``artifact`` (so the single-result path is unchanged) and the rest here.
+    extra_artifacts: tuple[TilingArtifacts, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -590,10 +669,71 @@ def _finalize_pending_tiling_preview(
     return artifact, row
 
 
+def _save_per_annotation_artifact(
+    result: TilingResult, *, output_dir: Path, annotation: str | None
+) -> TilingArtifacts:
+    artifact = save_tiling_result(result, output_dir=output_dir, annotation=annotation)
+    return TilingArtifacts(
+        sample_id=artifact.sample_id,
+        coordinates_npz_path=artifact.coordinates_npz_path,
+        coordinates_meta_path=artifact.coordinates_meta_path,
+        num_tiles=artifact.num_tiles,
+        tiles_tar_path=None,
+        mask_preview_path=artifact.mask_preview_path,
+        tiling_preview_path=artifact.tiling_preview_path,
+        backend=artifact.backend,
+        requested_backend=artifact.requested_backend,
+        annotation=annotation,
+    )
+
+
+def _compute_and_save_per_annotation(request: _ComputeRequest) -> _ComputeResponse:
+    """Compute + persist one TilingResult per active annotation, via the shared
+    ``_run_per_annotation`` core (same compute path as ``tile_slide``)."""
+    effective_segmentation = _resolve_effective_segmentation(
+        whole_slide=request.whole_slide,
+        segmentation=request.segmentation,
+    )
+    results = _run_per_annotation(
+        whole_slide=request.whole_slide,
+        tiling=request.tiling,
+        filtering=request.filtering,
+        sampling=request.sampling,
+        selection_strategy=(
+            request.sampling_selection_strategy
+            or CoordinateSelectionStrategy.JOINT_SAMPLING
+        ),
+        output_mode=(
+            request.sampling_output_mode or CoordinateOutputMode.PER_ANNOTATION
+        ),
+        seg_downsample=effective_segmentation.downsample,
+        num_workers=request.num_workers,
+    )
+    artifacts = [
+        _save_per_annotation_artifact(
+            result, output_dir=request.output_dir, annotation=annotation
+        )
+        for annotation, result in results.items()
+    ]
+    return _ComputeResponse(
+        input_index=request.input_index,
+        whole_slide=request.whole_slide,
+        ok=True,
+        artifact=artifacts[0],
+        extra_artifacts=tuple(artifacts[1:]),
+        result=None,
+        requested_backend=request.tiling.requested_backend,
+        backend=request.tiling.backend,
+        mask_preview_path=None,
+    )
+
+
 def _compute_and_save_tiling_artifacts_from_request(
     request: _ComputeRequest,
 ) -> _ComputeResponse:
     try:
+        if request.sampling is not None:
+            return _compute_and_save_per_annotation(request)
         defer_pixel_filtering = request.save_tiles and _needs_pixel_filtering(request.filtering)
         effective_filtering = (
             replace(
@@ -823,10 +963,31 @@ def tile_slides(
     save_tiles: bool = False,
     jpeg_backend: str = "turbojpeg",
     gpu_decode: bool = False,
+    sampling: SamplingSpec | None = None,
+    selection_strategy: str | None = None,
+    output_mode: str | None = None,
 ) -> list[TilingArtifacts]:
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     _validate_whole_slides(whole_slides)
+    if sampling is not None:
+        if not sampling.active_annotations:
+            raise ValueError("annotation sampling requires a non-empty sampling.active_annotations")
+        unsupported = [
+            name
+            for name, active in (
+                ("resume", resume),
+                ("read_coordinates_from", read_coordinates_from is not None),
+                ("save_tiles", save_tiles),
+                ("preview", preview is not None),
+            )
+            if active
+        ]
+        if unsupported:
+            raise NotImplementedError(
+                "tile_slides annotation sampling does not yet support: "
+                + ", ".join(unsupported)
+            )
     _validate_segmentation_requirement(
         whole_slides=whole_slides,
         segmentation=segmentation,
@@ -973,6 +1134,9 @@ def tile_slides(
                 jpeg_backend=str(jpeg_backend),
                 gpu_decode=gpu_decode,
                 save_tiles=save_tiles,
+                sampling=sampling,
+                sampling_selection_strategy=selection_strategy,
+                sampling_output_mode=output_mode,
             )
             planned_work.append(
                 _SlideWork(
@@ -989,15 +1153,21 @@ def tile_slides(
                     traceback_text=traceback.format_exc(),
                 )
             )
-    mask_resolution_requests = [
-        _MaskResolutionRequest(
-            input_index=request.input_index,
-            whole_slide=request.whole_slide,
-            tiling=request.tiling,
-            segmentation=request.segmentation,
-        )
-        for request in compute_requests
-    ]
+    # Annotation sampling resolves its (multi-class) mask inside the shared compute core, so
+    # it skips the tissue-mask pre-resolution stage entirely.
+    mask_resolution_requests = (
+        []
+        if sampling is not None
+        else [
+            _MaskResolutionRequest(
+                input_index=request.input_index,
+                whole_slide=request.whole_slide,
+                tiling=request.tiling,
+                segmentation=request.segmentation,
+            )
+            for request in compute_requests
+        ]
+    )
     resolved_masks: dict[int, ResolvedTissueMask] = {}
     mask_failures: dict[int, _MaskResolutionResponse] = {}
     if mask_resolution_requests:
@@ -1227,6 +1397,21 @@ def tile_slides(
                 artifact=artifact,
             )
         )
+        # Annotation sampling emits one extra artifact per additional active annotation.
+        for extra in getattr(response, "extra_artifacts", ()):
+            extra_artifact = _build_success_artifact(
+                base_artifact=extra,
+                mask_preview_path=None,
+                tiling_preview_path=None,
+            )
+            _record_tiling_success(num_tiles=extra_artifact.num_tiles)
+            artifacts.append(extra_artifact)
+            _record_process_row(
+                _build_success_process_row(
+                    whole_slide=response.whole_slide,
+                    artifact=extra_artifact,
+                )
+            )
 
     def _drain_planned_work(compute_response_iter) -> None:
         buffered_responses: dict[int, _ComputeResponse] = {}
@@ -1303,6 +1488,9 @@ def tile_slides(
                     gpu_decode=request.gpu_decode,
                     include_result=False,
                     save_tiles=request.save_tiles,
+                    sampling=request.sampling,
+                    sampling_selection_strategy=request.sampling_selection_strategy,
+                    sampling_output_mode=request.sampling_output_mode,
                 )
                 for request in compute_requests
             ]
@@ -1338,6 +1526,9 @@ def tile_slides(
                     gpu_decode=request.gpu_decode,
                     include_result=True,
                     save_tiles=request.save_tiles,
+                    sampling=request.sampling,
+                    sampling_selection_strategy=request.sampling_selection_strategy,
+                    sampling_output_mode=request.sampling_output_mode,
                 )
                 for request in compute_requests
             ]

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -1264,12 +1264,16 @@ def tile_slides(
             discovered_tiles=snapshot["discovered_tiles"],
         )
 
-    def _record_tiling_success(*, num_tiles: int) -> None:
+    def _record_tiling_success(*, num_tiles: int, increment_completed: bool = True) -> None:
+        # ``increment_completed`` counts one *slide* completion. Annotation sampling emits
+        # several artifacts per slide; the extra artifacts add their discovered tiles but must
+        # not inflate the slide-completion count (which is measured against total_slides).
         nonlocal tiling_completed, tiling_discovered_tiles, tiling_zero_tile_successes
-        tiling_completed += 1
+        if increment_completed:
+            tiling_completed += 1
+            if num_tiles == 0:
+                tiling_zero_tile_successes += 1
         tiling_discovered_tiles += num_tiles
-        if num_tiles == 0:
-            tiling_zero_tile_successes += 1
         _emit_tiling_progress()
 
     def _record_tiling_failure() -> None:
@@ -1404,7 +1408,9 @@ def tile_slides(
                 mask_preview_path=None,
                 tiling_preview_path=None,
             )
-            _record_tiling_success(num_tiles=extra_artifact.num_tiles)
+            _record_tiling_success(
+                num_tiles=extra_artifact.num_tiles, increment_completed=False
+            )
             artifacts.append(extra_artifact)
             _record_process_row(
                 _build_success_process_row(

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -523,6 +523,7 @@ def _build_success_artifact(
         backend=base_artifact.backend,
         requested_backend=base_artifact.requested_backend,
         annotation=base_artifact.annotation,
+        output_mode=base_artifact.output_mode,
     )
 
 
@@ -531,9 +532,22 @@ def _build_success_process_row(
     whole_slide: SlideSpec,
     artifact: TilingArtifacts,
 ) -> dict[str, Any]:
+    # A per-slide artifact with no annotation is binary tissue tiling, EXCEPT the merged
+    # SINGLE_OUTPUT annotation result (also annotation=None, but a union of annotation classes).
+    # Record output_mode and label the merged row "merged" so it is not mistaken for tissue.
+    if (
+        artifact.annotation is None
+        and artifact.output_mode == CoordinateOutputMode.SINGLE_OUTPUT
+    ):
+        annotation_label = "merged"
+    elif artifact.annotation is not None:
+        annotation_label = artifact.annotation
+    else:
+        annotation_label = "tissue"
     return {
         "sample_id": whole_slide.sample_id,
-        "annotation": artifact.annotation if artifact.annotation is not None else "tissue",
+        "annotation": annotation_label,
+        "output_mode": artifact.output_mode,
         "image_path": str(whole_slide.image_path),
         "mask_path": (
             str(whole_slide.mask_path) if whole_slide.mask_path is not None else None
@@ -629,6 +643,7 @@ def _build_failure_process_row(
     return {
         "sample_id": whole_slide.sample_id,
         "annotation": annotation,
+        "output_mode": None,
         "image_path": str(whole_slide.image_path),
         "mask_path": (
             str(whole_slide.mask_path) if whole_slide.mask_path is not None else None
@@ -684,6 +699,7 @@ def _save_per_annotation_artifact(
         backend=artifact.backend,
         requested_backend=artifact.requested_backend,
         annotation=annotation,
+        output_mode=artifact.output_mode,
     )
 
 

--- a/hs2p/tiling/single.py
+++ b/hs2p/tiling/single.py
@@ -14,6 +14,7 @@ from hs2p.tiling.result import ResolvedAnnotationMasks, ResolvedTissueMask, Tili
 from hs2p.tiling.mask import resolve_annotation_masks, resolve_tissue_mask
 from hs2p.tile_qc import filter_coordinate_tiles, needs_pixel_qc
 from hs2p.wsi.reader import open_slide
+from hs2p.wsi.types import CoordinateOutputMode, CoordinateSelectionStrategy
 
 
 def build_tiling_result_from_mask(
@@ -293,9 +294,15 @@ def _build_joint_annotation_results(
     qc_spacing_um: float,
     num_workers: int,
 ) -> "dict[str, TilingResult]":
-    union_mask = np.zeros_like(next(iter(resolved_masks.masks.values())))
-    for binary_mask in resolved_masks.masks.values():
-        union_mask = np.where(binary_mask > 0, np.uint8(255), union_mask).astype(np.uint8)
+    # Union over the classes actually being sampled (active_annotations) — never the full
+    # mask set, which may include declared-but-unsampled labels (e.g. the value reserved for
+    # unannotated pixels) that would otherwise swallow the whole slide.
+    active = sampling_spec.active_annotations
+    union_mask = np.zeros_like(resolved_masks.masks[active[0]])
+    for annotation in active:
+        union_mask = np.where(
+            resolved_masks.masks[annotation] > 0, np.uint8(255), union_mask
+        ).astype(np.uint8)
 
     union_resolved = ResolvedTissueMask(
         tissue_mask=union_mask,
@@ -400,8 +407,6 @@ def _merge_annotation_results_to_single(
     mask is attached downstream. ``tissue_fractions`` carries the max per-class
     coverage seen for each kept tile.
     """
-    from hs2p.wsi.types import CoordinateOutputMode
-
     result_list = list(results.values())
     if not result_list:
         raise ValueError(
@@ -483,8 +488,6 @@ def build_per_annotation_tiling_results(
     INDEPENDENT_SAMPLING: one tiling pass per annotation using that annotation's binary mask.
     JOINT_SAMPLING: one pass on the union mask, then per-annotation post-filter by coverage.
     """
-    from hs2p.wsi.types import CoordinateOutputMode, CoordinateSelectionStrategy
-
     if output_mode is None:
         output_mode = CoordinateOutputMode.PER_ANNOTATION
 

--- a/hs2p/tiling/single.py
+++ b/hs2p/tiling/single.py
@@ -11,7 +11,7 @@ from hs2p.tiling.contours import _normalize_level_downsamples, detect_contours
 from hs2p.tiling.coverage import compute_tile_coverage
 from hs2p.tiling.generate import generate_tiles
 from hs2p.tiling.result import ResolvedAnnotationMasks, ResolvedTissueMask, TilingResult
-from hs2p.tiling.mask import resolve_tissue_mask
+from hs2p.tiling.mask import resolve_annotation_masks, resolve_tissue_mask
 from hs2p.tile_qc import filter_coordinate_tiles, needs_pixel_qc
 from hs2p.wsi.reader import open_slide
 
@@ -388,6 +388,61 @@ def _build_joint_annotation_results(
     return results
 
 
+def _merge_annotation_results_to_single(
+    results: "dict[str, TilingResult]",
+) -> "TilingResult":
+    """Collapse a per-annotation result dict into one merged result for SINGLE_OUTPUT.
+
+    The merged result is the **union** of every tile that passes *any* active
+    annotation's coverage threshold (dedup'd over the shared candidate grid), with
+    ``annotation=None``. Each spatial tile therefore appears once — the dense
+    segmentation contract, where one tile is encoded once and its full multi-class
+    mask is attached downstream. ``tissue_fractions`` carries the max per-class
+    coverage seen for each kept tile.
+    """
+    from hs2p.wsi.types import CoordinateOutputMode
+
+    result_list = list(results.values())
+    if not result_list:
+        raise ValueError(
+            "SINGLE_OUTPUT merge requires at least one annotation result; got none "
+            "(no active annotations in the sampling spec?)"
+        )
+    template = result_list[0]
+    all_x = np.concatenate([np.asarray(r.tiles.x) for r in result_list])
+    all_y = np.concatenate([np.asarray(r.tiles.y) for r in result_list])
+    all_fracs = np.concatenate(
+        [np.asarray(r.tiles.tissue_fractions) for r in result_list]
+    )
+    if all_x.size:
+        coords = np.stack([all_x, all_y], axis=1)
+        # np.unique(axis=0) returns lexicographically-sorted unique rows → deterministic.
+        uniq, inverse = np.unique(coords, axis=0, return_inverse=True)
+        merged_x = uniq[:, 0].astype(template.tiles.x.dtype)
+        merged_y = uniq[:, 1].astype(template.tiles.y.dtype)
+        merged_fracs = np.zeros(len(uniq), dtype=all_fracs.dtype)
+        np.maximum.at(merged_fracs, inverse.ravel(), all_fracs)
+    else:
+        merged_x = np.asarray(template.tiles.x)[:0]
+        merged_y = np.asarray(template.tiles.y)[:0]
+        merged_fracs = np.asarray(template.tiles.tissue_fractions)[:0]
+
+    merged_tiles = replace(
+        template.tiles,
+        x=merged_x,
+        y=merged_y,
+        tissue_fractions=merged_fracs,
+        tile_index=np.arange(len(merged_x), dtype=np.int32),
+        min_tissue_fraction=0.0,
+    )
+    return replace(
+        template,
+        tiles=merged_tiles,
+        annotation=None,
+        output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+    )
+
+
 def build_per_annotation_tiling_results(
     *,
     slide,
@@ -469,14 +524,20 @@ def build_per_annotation_tiling_results(
     )
 
     if selection_strategy == CoordinateSelectionStrategy.INDEPENDENT_SAMPLING:
-        return _build_independent_annotation_results(**_shared)
+        results = _build_independent_annotation_results(**_shared)
     elif selection_strategy == CoordinateSelectionStrategy.JOINT_SAMPLING:
-        return _build_joint_annotation_results(**_shared)
+        results = _build_joint_annotation_results(**_shared)
     else:
         raise ValueError(
             f"selection_strategy must be INDEPENDENT_SAMPLING or JOINT_SAMPLING, "
             f"got {selection_strategy!r}"
         )
+
+    if output_mode == CoordinateOutputMode.SINGLE_OUTPUT:
+        # One merged result per slide (union of tiles passing any class threshold),
+        # keyed by None so tile_slide/tile_slides persist a single per-slide artifact.
+        return {None: _merge_annotation_results_to_single(results)}
+    return results
 
 
 def preprocess_slide(
@@ -579,8 +640,92 @@ def preprocess_slide(
         slide.close()
 
 
+def preprocess_slide_per_annotation(
+    *,
+    image_path: str | Path,
+    mask_path: str | Path,
+    pixel_mapping: dict[str, int],
+    sampling_spec: Any,
+    selection_strategy: str,
+    sample_id: str | None = None,
+    backend: str = "auto",
+    spacing_override: float | None = None,
+    requested_tile_size_px: int = 256,
+    requested_spacing_um: float = 0.5,
+    overlap: float = 0.0,
+    seg_downsample: int = 64,
+    tolerance: float = 0.05,
+    ref_tile_size_px: int = 16,
+    a_t: int = 4,
+    a_h: int = 0,
+    filter_white: bool = False,
+    filter_black: bool = False,
+    white_threshold: int = 220,
+    black_threshold: int = 25,
+    fraction_threshold: float = 0.9,
+    filter_grayspace: bool = False,
+    grayspace_saturation_threshold: float = 0.05,
+    grayspace_fraction_threshold: float = 0.6,
+    filter_blur: bool = False,
+    blur_threshold: float = 50.0,
+    qc_spacing_um: float = 2.0,
+    num_workers: int = 1,
+    output_mode: str | None = None,
+) -> "dict[str, TilingResult]":
+    """Annotation-aware tiling: open the slide, resolve its annotation mask into per-class
+    binaries (:func:`resolve_annotation_masks`), then sample per active annotation.
+
+    The annotation counterpart of :func:`preprocess_slide` — it returns one
+    :class:`TilingResult` per active annotation (keyed by name) instead of a single tissue
+    result, wiring the previously-orphaned :func:`build_per_annotation_tiling_results` to a
+    real mask. ``selection_strategy`` selects INDEPENDENT vs JOINT sampling; ``output_mode``
+    selects single vs per-annotation coordinate output.
+    """
+    slide = open_slide(image_path, backend=backend, spacing_override=spacing_override)
+    try:
+        resolved_masks = resolve_annotation_masks(
+            slide=slide,
+            mask_path=mask_path,
+            pixel_mapping=pixel_mapping,
+            seg_downsample=seg_downsample,
+        )
+        return build_per_annotation_tiling_results(
+            slide=slide,
+            resolved_masks=resolved_masks,
+            sampling_spec=sampling_spec,
+            selection_strategy=selection_strategy,
+            image_path=image_path,
+            backend=slide.backend_name,
+            requested_backend=backend,
+            sample_id=sample_id,
+            requested_tile_size_px=requested_tile_size_px,
+            requested_spacing_um=requested_spacing_um,
+            overlap=overlap,
+            tolerance=tolerance,
+            ref_tile_size_px=ref_tile_size_px,
+            a_t=a_t,
+            a_h=a_h,
+            filter_white=filter_white,
+            filter_black=filter_black,
+            white_threshold=white_threshold,
+            black_threshold=black_threshold,
+            fraction_threshold=fraction_threshold,
+            filter_grayspace=filter_grayspace,
+            grayspace_saturation_threshold=grayspace_saturation_threshold,
+            grayspace_fraction_threshold=grayspace_fraction_threshold,
+            filter_blur=filter_blur,
+            blur_threshold=blur_threshold,
+            qc_spacing_um=qc_spacing_um,
+            num_workers=num_workers,
+            output_mode=output_mode,
+        )
+    finally:
+        slide.close()
+
+
 __all__ = [
     "build_per_annotation_tiling_results",
     "build_tiling_result_from_mask",
     "preprocess_slide",
+    "preprocess_slide_per_annotation",
 ]

--- a/hs2p/tiling/single.py
+++ b/hs2p/tiling/single.py
@@ -490,6 +490,16 @@ def build_per_annotation_tiling_results(
     """
     if output_mode is None:
         output_mode = CoordinateOutputMode.PER_ANNOTATION
+    # Validate here (the shared chokepoint for both the CLI and the public tile_slide/
+    # tile_slides API), so an invalid value fails fast instead of silently falling through
+    # to per-annotation output and recording a bogus mode in metadata/process_list.
+    if output_mode not in (
+        CoordinateOutputMode.PER_ANNOTATION,
+        CoordinateOutputMode.SINGLE_OUTPUT,
+    ):
+        raise ValueError(
+            f"output_mode must be PER_ANNOTATION or SINGLE_OUTPUT, got {output_mode!r}"
+        )
 
     _shared = dict(
         resolved_masks=resolved_masks,

--- a/hs2p/wsi/masks.py
+++ b/hs2p/wsi/masks.py
@@ -30,6 +30,39 @@ def read_label_at_spacing(
     arr = wsi.read_full_at_spacing(
         requested_spacing_um, tolerance=tolerance, interpolation="nearest"
     )
+    return _collapse_label_raster(arr)
+
+
+def read_label_region_at_spacing(
+    wsi,
+    location: tuple[int, int],
+    requested_spacing_um: float,
+    size: tuple[int, int],
+    *,
+    tolerance: float,
+) -> np.ndarray:
+    """Read a multi-class label *region* at ``requested_spacing_um``, preserving class ids.
+
+    The region counterpart of :func:`read_label_at_spacing` (for annotation-sampled ROIs):
+    nearest-neighbor resample via :meth:`hs2p.wsi.wsi.WSI.read_region_at_spacing`, then
+    collapse the channel-replicated raster back to a single-channel integer mask.
+
+    Args:
+        location: ``(x, y)`` top-left in level-0 pixel space.
+        size: Output ``(width, height)`` in pixels at ``requested_spacing_um``.
+    """
+    arr = wsi.read_region_at_spacing(
+        location,
+        requested_spacing_um,
+        size,
+        tolerance=tolerance,
+        interpolation="nearest",
+    )
+    return _collapse_label_raster(arr)
+
+
+def _collapse_label_raster(arr: np.ndarray) -> np.ndarray:
+    """Recover a 2-D integer class-index raster from a (possibly RGB-replicated) read."""
     if arr.ndim == 3:
         channels = arr.shape[2]
         if channels >= 3 and not (

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -230,6 +230,42 @@ def test_openslide_fallback_recovers_when_primary_read_rejects_all_zero(monkeypa
     assert int(np.count_nonzero(resolved.masks["stroma"])) == SLIDE_H * (SLIDE_W // 2)
 
 
+def test_openslide_fallback_accepts_valid_all_zero_after_primary_error(monkeypatch):
+    """Primary read raises (e.g. a decode error), openslide recovers a valid all-zero mask.
+
+    With background (0) declared, an all-zero raster is a legitimate read — the fallback must
+    be accepted even though it has no foreground, instead of re-raising the primary error.
+    """
+
+    class _RaisingMaskSlide:
+        spacing = BASE_SPACING
+        level_dimensions = [(SLIDE_W, SLIDE_H)]
+        level_downsamples = [1.0]
+
+        def read_region(self, location, level, size):
+            raise RuntimeError("backend decode error")
+
+        def close(self):
+            return None
+
+    empty = np.zeros((SLIDE_H, SLIDE_W), dtype=np.uint8)
+
+    def fake_open(path, backend=None):
+        if str(backend).lower() == "openslide":
+            return _FakeMaskSlide(empty, BASE_SPACING)  # valid: 0 is declared background
+        return _RaisingMaskSlide()  # primary backend raises
+
+    monkeypatch.setattr(maskmod, "open_slide", fake_open)
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping={"background": 0, "tumor": 1},
+        seg_downsample=1,
+    )
+    assert int(np.count_nonzero(resolved.masks["tumor"])) == 0
+    assert int(np.count_nonzero(resolved.masks["background"])) == SLIDE_H * SLIDE_W
+
+
 def test_resolve_annotation_masks_genuinely_empty_stays_empty(monkeypatch):
     """When every backend agrees the mask is background, no spurious real labels are invented.
 

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -76,17 +76,21 @@ def patched_mask_open(monkeypatch):
     return mask
 
 
-def test_resolve_annotation_masks_splits_per_non_background_class(patched_mask_open):
+def test_resolve_annotation_masks_splits_per_declared_label(patched_mask_open):
     resolved = resolve_annotation_masks(
         slide=_mock_slide(),
         mask_path="/fake/slide_mask.tif",
         pixel_mapping=PIXEL_MAPPING,
         seg_downsample=1,
     )
-    assert set(resolved.masks) == {"tumor", "stroma", "necrosis"}
+    # No reserved name: every declared label gets a binary, including "background".
+    assert set(resolved.masks) == {"background", "tumor", "stroma", "necrosis"}
     assert int(np.count_nonzero(resolved.masks["tumor"])) == TUMOR_PX
     assert int(np.count_nonzero(resolved.masks["stroma"])) == STROMA_PX
     assert int(np.count_nonzero(resolved.masks["necrosis"])) == NECROSIS_PX
+    assert int(np.count_nonzero(resolved.masks["background"])) == (
+        SLIDE_H * SLIDE_W - TUMOR_PX - STROMA_PX - NECROSIS_PX
+    )
     # binaries are 0 / 255
     assert set(np.unique(resolved.masks["tumor"]).tolist()) <= {0, 255}
     assert resolved.seg_spacing_um == pytest.approx(BASE_SPACING)
@@ -94,14 +98,53 @@ def test_resolve_annotation_masks_splits_per_non_background_class(patched_mask_o
     assert resolved.pixel_mapping == PIXEL_MAPPING
 
 
-def test_resolve_annotation_masks_requires_background(patched_mask_open):
-    with pytest.raises(ValueError, match="background"):
-        resolve_annotation_masks(
-            slide=_mock_slide(),
-            mask_path="/fake/slide_mask.tif",
-            pixel_mapping={"tumor": 1},
-            seg_downsample=1,
-        )
+def test_resolve_annotation_masks_preserves_uint16_labels_above_255(monkeypatch):
+    """Label values above 255 stored in a uint16 raster must not wrap to uint8.
+
+    The reader validates labels against the full pixel-value set (which is not bounded to
+    255), so an unconditional uint8 downcast would wrap e.g. 300 -> 44, silently dropping a
+    class or merging it into whichever class owns the wrapped value.
+    """
+    mask = np.zeros((SLIDE_H, SLIDE_W), dtype=np.uint16)
+    mask[0:200, 0:200] = 300  # would wrap to 44 under a uint8 downcast
+    mask[200:400, 200:400] = 600  # would wrap to 88
+    monkeypatch.setattr(
+        maskmod,
+        "open_slide",
+        lambda path, backend=None: _FakeMaskSlide(mask, BASE_SPACING),
+    )
+
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping={"background": 0, "tumor": 300, "stroma": 600},
+        seg_downsample=1,
+    )
+    assert int(np.count_nonzero(resolved.masks["tumor"])) == 200 * 200
+    assert int(np.count_nonzero(resolved.masks["stroma"])) == 200 * 200
+
+
+def test_resolve_annotation_masks_background_is_optional(monkeypatch):
+    """A raster that labels every pixel (no reserved background value) needs no 'background'
+    entry — every declared class still validates and is split into a binary."""
+    mask = np.zeros((SLIDE_H, SLIDE_W), dtype=np.uint8)
+    mask[:, : SLIDE_W // 2] = 1  # tumor over the left half
+    mask[:, SLIDE_W // 2 :] = 2  # stroma over the right half
+    monkeypatch.setattr(
+        maskmod,
+        "open_slide",
+        lambda path, backend=None: _FakeMaskSlide(mask, BASE_SPACING),
+    )
+
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping={"tumor": 1, "stroma": 2},
+        seg_downsample=1,
+    )
+    assert set(resolved.masks) == {"tumor", "stroma"}
+    assert int(np.count_nonzero(resolved.masks["tumor"])) == SLIDE_H * (SLIDE_W // 2)
+    assert int(np.count_nonzero(resolved.masks["stroma"])) == SLIDE_H * (SLIDE_W // 2)
 
 
 def test_summarize_annotation_coverage_area_frac_and_est_tiles(patched_mask_open):
@@ -159,7 +202,11 @@ def test_resolve_annotation_masks_recovers_via_openslide_on_degenerate_read(monk
 
 
 def test_resolve_annotation_masks_genuinely_empty_stays_empty(monkeypatch):
-    """When every backend agrees the mask is background, no spurious labels are invented."""
+    """When every backend agrees the mask is background, no spurious real labels are invented.
+
+    The background binary correctly fills the slide (every pixel is the background value); the
+    point is that no foreground class picks up phantom pixels.
+    """
     empty = np.zeros((SLIDE_H, SLIDE_W), dtype=np.uint8)
     monkeypatch.setattr(
         maskmod, "open_slide", lambda path, backend=None: _FakeMaskSlide(empty, BASE_SPACING)
@@ -170,7 +217,11 @@ def test_resolve_annotation_masks_genuinely_empty_stays_empty(monkeypatch):
         pixel_mapping=PIXEL_MAPPING,
         seg_downsample=1,
     )
-    assert all(int(np.count_nonzero(m)) == 0 for m in resolved.masks.values())
+    assert all(
+        int(np.count_nonzero(resolved.masks[name])) == 0
+        for name in ("tumor", "stroma", "necrosis")
+    )
+    assert int(np.count_nonzero(resolved.masks["background"])) == SLIDE_H * SLIDE_W
 
 
 class _FakeSlide:

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -1,0 +1,464 @@
+"""Tests for the annotation-mask producer (resolve_annotation_masks) and the per-class
+coverage summary (summarize_annotation_coverage) — the previously-missing keystone for
+build_per_annotation_tiling_results, plus the coverage utility soma's ingestion drives."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import hs2p.tiling.mask as maskmod
+import hs2p.tiling.orchestration as orchmod
+import hs2p.tiling.single as singlemod
+import pandas as pd
+
+from hs2p.api import FilterConfig, SlideSpec, TilingConfig, tile_slide, tile_slides
+from hs2p.tiling.coverage import summarize_annotation_coverage
+from hs2p.tiling.mask import resolve_annotation_masks
+from hs2p.tiling.single import preprocess_slide_per_annotation
+from hs2p.wsi.types import CoordinateOutputMode, CoordinateSelectionStrategy, SamplingSpec
+
+BASE_SPACING = 0.5
+SLIDE_W, SLIDE_H = 400, 400
+PIXEL_MAPPING = {"background": 0, "tumor": 1, "stroma": 2, "necrosis": 3}
+
+# Areas (in level-0 == seg pixels here, downsample 1):
+#   tumor    200x200 = 40000
+#   stroma   200x200 = 40000
+#   necrosis  40x40  =  1600   (a small focus in the top-right corner)
+TUMOR_PX, STROMA_PX, NECROSIS_PX = 40000, 40000, 1600
+
+
+def _label_mask() -> np.ndarray:
+    mask = np.zeros((SLIDE_H, SLIDE_W), dtype=np.uint8)
+    mask[0:200, 0:200] = 1
+    mask[200:400, 200:400] = 2
+    mask[0:40, 360:400] = 3
+    return mask
+
+
+class _FakeMaskSlide:
+    """Single-level label-mask slide; read_region returns the label replicated to RGB."""
+
+    def __init__(self, mask: np.ndarray, spacing: float):
+        self._mask = mask
+        self.spacing = spacing
+        height, width = mask.shape
+        self.level_dimensions = [(width, height)]
+        self.level_downsamples = [1.0]
+
+    def read_region(self, location, level, size):
+        del location, level, size
+        return np.repeat(self._mask[:, :, None], 3, axis=2)
+
+    def close(self) -> None:
+        return None
+
+
+def _mock_slide() -> SimpleNamespace:
+    return SimpleNamespace(
+        dimensions=(SLIDE_W, SLIDE_H),
+        spacing=BASE_SPACING,
+        level_downsamples=[1.0],
+        level_dimensions=[(SLIDE_W, SLIDE_H)],
+        backend_name="mock",
+    )
+
+
+@pytest.fixture
+def patched_mask_open(monkeypatch):
+    mask = _label_mask()
+    monkeypatch.setattr(
+        maskmod,
+        "open_slide",
+        lambda path, backend=None: _FakeMaskSlide(mask, BASE_SPACING),
+    )
+    return mask
+
+
+def test_resolve_annotation_masks_splits_per_non_background_class(patched_mask_open):
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping=PIXEL_MAPPING,
+        seg_downsample=1,
+    )
+    assert set(resolved.masks) == {"tumor", "stroma", "necrosis"}
+    assert int(np.count_nonzero(resolved.masks["tumor"])) == TUMOR_PX
+    assert int(np.count_nonzero(resolved.masks["stroma"])) == STROMA_PX
+    assert int(np.count_nonzero(resolved.masks["necrosis"])) == NECROSIS_PX
+    # binaries are 0 / 255
+    assert set(np.unique(resolved.masks["tumor"]).tolist()) <= {0, 255}
+    assert resolved.seg_spacing_um == pytest.approx(BASE_SPACING)
+    assert resolved.seg_downsample == 1
+    assert resolved.pixel_mapping == PIXEL_MAPPING
+
+
+def test_resolve_annotation_masks_requires_background(patched_mask_open):
+    with pytest.raises(ValueError, match="background"):
+        resolve_annotation_masks(
+            slide=_mock_slide(),
+            mask_path="/fake/slide_mask.tif",
+            pixel_mapping={"tumor": 1},
+            seg_downsample=1,
+        )
+
+
+def test_summarize_annotation_coverage_area_frac_and_est_tiles(patched_mask_open):
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping=PIXEL_MAPPING,
+        seg_downsample=1,
+    )
+    summary = summarize_annotation_coverage(
+        slide=_mock_slide(),
+        resolved_masks=resolved,
+        min_coverage={"tumor": 0.1, "stroma": 0.1, "necrosis": 0.1},
+        requested_tile_size_px=200,
+        requested_spacing_um=BASE_SPACING,
+        overlap=0.0,
+    )
+
+    mm2_per_px = (BASE_SPACING / 1000.0) ** 2
+    total = TUMOR_PX + STROMA_PX + NECROSIS_PX
+
+    assert summary["tumor"]["area_mm2"] == pytest.approx(TUMOR_PX * mm2_per_px)
+    assert summary["tumor"]["frac"] == pytest.approx(TUMOR_PX / total)
+    assert summary["necrosis"]["frac"] == pytest.approx(NECROSIS_PX / total)
+
+    # 2x2 grid of 200px tiles: tumor fills one tile, stroma fills one tile.
+    assert summary["tumor"]["est_tiles"] == 1
+    assert summary["stroma"]["est_tiles"] == 1
+    # The necrosis focus covers only 1600/40000 = 0.04 of its tile (< 0.1) → ~0 tiles,
+    # i.e. "present but trace" reads as no usable tiles (the design's intent).
+    assert summary["necrosis"]["est_tiles"] == 0
+
+
+def test_resolve_annotation_masks_recovers_via_openslide_on_degenerate_read(monkeypatch):
+    """A backend that mis-decodes the mask to all-background (cucim + compressed minisblack)
+    is recovered by the openslide fallback."""
+    labeled = _label_mask()
+    empty = np.zeros_like(labeled)
+
+    def fake_open(path, backend=None):
+        if str(backend).lower() == "openslide":
+            return _FakeMaskSlide(labeled, BASE_SPACING)
+        return _FakeMaskSlide(empty, BASE_SPACING)
+
+    monkeypatch.setattr(maskmod, "open_slide", fake_open)
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping=PIXEL_MAPPING,
+        seg_downsample=1,
+    )
+    assert int(np.count_nonzero(resolved.masks["tumor"])) == TUMOR_PX
+    assert int(np.count_nonzero(resolved.masks["stroma"])) == STROMA_PX
+    assert int(np.count_nonzero(resolved.masks["necrosis"])) == NECROSIS_PX
+
+
+def test_resolve_annotation_masks_genuinely_empty_stays_empty(monkeypatch):
+    """When every backend agrees the mask is background, no spurious labels are invented."""
+    empty = np.zeros((SLIDE_H, SLIDE_W), dtype=np.uint8)
+    monkeypatch.setattr(
+        maskmod, "open_slide", lambda path, backend=None: _FakeMaskSlide(empty, BASE_SPACING)
+    )
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping=PIXEL_MAPPING,
+        seg_downsample=1,
+    )
+    assert all(int(np.count_nonzero(m)) == 0 for m in resolved.masks.values())
+
+
+class _FakeSlide:
+    """Minimal single-level slide reader for the per-annotation tiling path."""
+
+    def __init__(self):
+        self.dimensions = (SLIDE_W, SLIDE_H)
+        self.spacing = BASE_SPACING
+        self.level_downsamples = [1.0]
+        self.level_dimensions = [(SLIDE_W, SLIDE_H)]
+        self.backend_name = "mock"
+
+    def read_region(self, location, level, size):
+        del location, level
+        width, height = int(size[0]), int(size[1])
+        return np.full((height, width, 3), 255, np.uint8)
+
+    def close(self) -> None:
+        return None
+
+
+def _sampling_spec():
+    return SamplingSpec(
+        pixel_mapping=PIXEL_MAPPING,
+        color_mapping=None,
+        tissue_percentage={"background": None, "tumor": 0.1, "stroma": 0.1, "necrosis": 0.1},
+        active_annotations=("tumor", "stroma", "necrosis"),
+    )
+
+
+@pytest.fixture
+def patched_slide_and_mask_open(monkeypatch):
+    mask = _label_mask()
+
+    def fake_open(path, backend="auto", spacing_override=None):
+        del spacing_override
+        if "mask" in str(path).lower():
+            return _FakeMaskSlide(mask, BASE_SPACING)
+        return _FakeSlide()
+
+    monkeypatch.setattr(singlemod, "open_slide", fake_open)
+    monkeypatch.setattr(maskmod, "open_slide", fake_open)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        CoordinateSelectionStrategy.JOINT_SAMPLING,
+        CoordinateSelectionStrategy.INDEPENDENT_SAMPLING,
+    ],
+)
+def test_preprocess_slide_per_annotation_wires_producer_to_sampler(
+    patched_slide_and_mask_open, strategy
+):
+    results = preprocess_slide_per_annotation(
+        image_path="/fake/slide.tif",
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping=PIXEL_MAPPING,
+        sampling_spec=_sampling_spec(),
+        selection_strategy=strategy,
+        sample_id="slide0",
+        requested_tile_size_px=64,
+        requested_spacing_um=BASE_SPACING,
+        seg_downsample=1,
+        a_t=0,
+    )
+    assert set(results) == {"tumor", "stroma", "necrosis"}
+    # tumor annotation occupies the top-left quadrant → its tiles stay there (origins < 200,
+    # since tumor ends at row/col 200 and a tile origin >= 200 cannot overlap it).
+    tumor = results["tumor"]
+    assert tumor.num_tiles > 0
+    assert (tumor.tiles.x < 200).all() and (tumor.tiles.y < 200).all()
+    # stroma occupies the bottom-right quadrant; with a 64px grid the earliest origin that
+    # can overlap the region starting at 200 is 192 (spans [192, 256)).
+    stroma = results["stroma"]
+    assert stroma.num_tiles > 0
+    assert (stroma.tiles.x >= 192).all() and (stroma.tiles.y >= 192).all()
+
+
+def test_tile_slide_with_sampling_returns_per_annotation_dict(monkeypatch):
+    """tile_slide(..., sampling=spec) dispatches to the shared annotation core and returns
+    one TilingResult per active annotation — same capability as tile_slides (no divergence)."""
+    mask = _label_mask()
+
+    def fake_open(path, backend="auto", spacing_override=None):
+        del spacing_override
+        if "mask" in str(path).lower():
+            return _FakeMaskSlide(mask, BASE_SPACING)
+        return _FakeSlide()
+
+    monkeypatch.setattr(singlemod, "open_slide", fake_open)
+    monkeypatch.setattr(maskmod, "open_slide", fake_open)
+    monkeypatch.setattr(
+        orchmod,
+        "resolve_backend",
+        lambda *a, **k: SimpleNamespace(backend="mock", reason=None),
+    )
+
+    whole_slide = SlideSpec(
+        sample_id="slide0",
+        image_path="/fake/slide.tif",
+        mask_path="/fake/slide_mask.tif",
+    )
+    tiling = TilingConfig(
+        requested_spacing_um=BASE_SPACING,
+        requested_tile_size_px=64,
+        tolerance=0.05,
+        overlap=0.0,
+        tissue_threshold=0.0,
+        backend="mock",
+    )
+    result = tile_slide(
+        whole_slide,
+        tiling=tiling,
+        filtering=FilterConfig(a_t=0),
+        sampling=_sampling_spec(),
+        selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+    )
+    assert isinstance(result, dict)
+    assert set(result) == {"tumor", "stroma", "necrosis"}
+    assert result["tumor"].num_tiles > 0
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        CoordinateSelectionStrategy.JOINT_SAMPLING,
+        CoordinateSelectionStrategy.INDEPENDENT_SAMPLING,
+    ],
+)
+def test_single_output_merges_to_one_deduped_result_per_slide(
+    patched_slide_and_mask_open, strategy
+):
+    """SINGLE_OUTPUT collapses the per-annotation fan-out into one merged result keyed by
+    None: the dedup'd union of every tile passing any class threshold (the dense-seg
+    contract — each spatial tile once, multi-class mask attached downstream)."""
+    common = dict(
+        image_path="/fake/slide.tif",
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping=PIXEL_MAPPING,
+        sampling_spec=_sampling_spec(),
+        selection_strategy=strategy,
+        sample_id="slide0",
+        requested_tile_size_px=64,
+        requested_spacing_um=BASE_SPACING,
+        seg_downsample=1,
+        a_t=0,
+    )
+    per_anno = preprocess_slide_per_annotation(
+        output_mode=CoordinateOutputMode.PER_ANNOTATION, **common
+    )
+    single = preprocess_slide_per_annotation(
+        output_mode=CoordinateOutputMode.SINGLE_OUTPUT, **common
+    )
+
+    # one entry, keyed None, annotation cleared, output_mode tagged
+    assert set(single) == {None}
+    merged = single[None]
+    assert merged.annotation is None
+    assert merged.output_mode == CoordinateOutputMode.SINGLE_OUTPUT
+
+    # merged coords == sorted unique union of the per-annotation coords
+    expected = set()
+    for res in per_anno.values():
+        expected.update(zip(res.tiles.x.tolist(), res.tiles.y.tolist()))
+    got = list(zip(merged.tiles.x.tolist(), merged.tiles.y.tolist()))
+    assert len(got) == len(set(got))  # no duplicates
+    assert set(got) == expected
+    assert merged.num_tiles == len(expected) > 0
+    # tile_index is a fresh contiguous range over the merged set
+    assert merged.tiles.tile_index.tolist() == list(range(merged.num_tiles))
+
+
+def _patch_tile_slides_open(monkeypatch):
+    mask = _label_mask()
+
+    def fake_open(path, backend="auto", spacing_override=None):
+        del spacing_override
+        if "mask" in str(path).lower():
+            return _FakeMaskSlide(mask, BASE_SPACING)
+        return _FakeSlide()
+
+    monkeypatch.setattr(singlemod, "open_slide", fake_open)
+    monkeypatch.setattr(maskmod, "open_slide", fake_open)
+    monkeypatch.setattr(
+        orchmod,
+        "resolve_backend",
+        lambda *a, **k: SimpleNamespace(backend="mock", reason=None),
+    )
+
+
+def _slides(n):
+    return [
+        SlideSpec(
+            sample_id=f"slide{i}",
+            image_path=f"/fake/slide{i}.tif",
+            mask_path=f"/fake/slide{i}_mask.tif",
+        )
+        for i in range(n)
+    ]
+
+
+def _mock_tiling():
+    return TilingConfig(
+        requested_spacing_um=BASE_SPACING,
+        requested_tile_size_px=64,
+        tolerance=0.05,
+        overlap=0.0,
+        tissue_threshold=0.0,
+        backend="mock",
+    )
+
+
+def test_tile_slides_with_sampling_emits_one_artifact_per_slide_annotation(monkeypatch, tmp_path):
+    _patch_tile_slides_open(monkeypatch)
+    artifacts = tile_slides(
+        _slides(2),
+        tiling=_mock_tiling(),
+        filtering=FilterConfig(a_t=0),
+        output_dir=tmp_path,
+        num_workers=1,
+        sampling=_sampling_spec(),
+        selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+    )
+    # 2 slides × 3 active annotations = 6 artifacts, each tagged with its annotation.
+    assert len(artifacts) == 6
+    assert {a.annotation for a in artifacts} == {"tumor", "stroma", "necrosis"}
+
+    rows = pd.read_csv(tmp_path / "process_list.csv")
+    assert len(rows) == 6
+    assert set(rows["annotation"]) == {"tumor", "stroma", "necrosis"}
+    assert "tissue" not in set(rows["annotation"])  # sampling path, never the tissue label
+    assert (rows["tiling_status"] == "success").all()
+
+
+def test_tile_slides_single_output_emits_one_artifact_per_slide(monkeypatch, tmp_path):
+    """With SINGLE_OUTPUT the sampling fan-out collapses: one artifact / process_list row
+    per slide (annotation None), which soma's per-slide extraction path consumes unchanged."""
+    _patch_tile_slides_open(monkeypatch)
+    artifacts = tile_slides(
+        _slides(2),
+        tiling=_mock_tiling(),
+        filtering=FilterConfig(a_t=0),
+        output_dir=tmp_path,
+        num_workers=1,
+        sampling=_sampling_spec(),
+        selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+        output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+    )
+    assert len(artifacts) == 2  # one per slide, not per (slide, annotation)
+    assert {a.sample_id for a in artifacts} == {"slide0", "slide1"}
+    assert all(a.annotation is None for a in artifacts)
+
+    rows = pd.read_csv(tmp_path / "process_list.csv")
+    assert len(rows) == 2
+    assert set(rows["sample_id"]) == {"slide0", "slide1"}
+    assert (rows["tiling_status"] == "success").all()
+    assert (rows["num_tiles"] > 0).all()
+
+
+def test_tile_slides_sampling_rejects_unsupported_combos(monkeypatch, tmp_path):
+    _patch_tile_slides_open(monkeypatch)
+    with pytest.raises(NotImplementedError, match="resume"):
+        tile_slides(
+            _slides(1),
+            tiling=_mock_tiling(),
+            filtering=FilterConfig(a_t=0),
+            output_dir=tmp_path,
+            num_workers=1,
+            sampling=_sampling_spec(),
+            resume=True,
+        )
+
+
+def test_summarize_annotation_coverage_est_tiles_none_without_threshold(patched_mask_open):
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping=PIXEL_MAPPING,
+        seg_downsample=1,
+    )
+    summary = summarize_annotation_coverage(
+        slide=_mock_slide(),
+        resolved_masks=resolved,
+        min_coverage={"tumor": 0.1},  # only tumor has a threshold
+        requested_tile_size_px=200,
+        requested_spacing_um=BASE_SPACING,
+    )
+    assert summary["tumor"]["est_tiles"] == 1
+    assert summary["stroma"]["est_tiles"] is None
+    assert summary["necrosis"]["est_tiles"] is None

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -201,6 +201,35 @@ def test_resolve_annotation_masks_recovers_via_openslide_on_degenerate_read(monk
     assert int(np.count_nonzero(resolved.masks["necrosis"])) == NECROSIS_PX
 
 
+def test_openslide_fallback_recovers_when_primary_read_rejects_all_zero(monkeypatch):
+    """No-background vocabulary + a degenerate all-zero primary read.
+
+    With no declared 0, the all-zero mis-decoded level fails the discreteness guard and the
+    primary read *raises* (rather than returning an empty mask). The openslide fallback must
+    still kick in and recover the labels — otherwise the slide errors out.
+    """
+    # Fully-labeled raster (only values 1/2, no background) so the openslide read validates.
+    labeled = np.empty((SLIDE_H, SLIDE_W), dtype=np.uint8)
+    labeled[:, : SLIDE_W // 2] = 1
+    labeled[:, SLIDE_W // 2 :] = 2
+    empty = np.zeros_like(labeled)
+
+    def fake_open(path, backend=None):
+        if str(backend).lower() == "openslide":
+            return _FakeMaskSlide(labeled, BASE_SPACING)
+        return _FakeMaskSlide(empty, BASE_SPACING)  # cucim mis-decode → all zero → rejected
+
+    monkeypatch.setattr(maskmod, "open_slide", fake_open)
+    resolved = resolve_annotation_masks(
+        slide=_mock_slide(),
+        mask_path="/fake/slide_mask.tif",
+        pixel_mapping={"tumor": 1, "stroma": 2},
+        seg_downsample=1,
+    )
+    assert int(np.count_nonzero(resolved.masks["tumor"])) == SLIDE_H * (SLIDE_W // 2)
+    assert int(np.count_nonzero(resolved.masks["stroma"])) == SLIDE_H * (SLIDE_W // 2)
+
+
 def test_resolve_annotation_masks_genuinely_empty_stays_empty(monkeypatch):
     """When every backend agrees the mask is background, no spurious real labels are invented.
 
@@ -455,6 +484,30 @@ def test_tile_slides_with_sampling_emits_one_artifact_per_slide_annotation(monke
     assert set(rows["annotation"]) == {"tumor", "stroma", "necrosis"}
     assert "tissue" not in set(rows["annotation"])  # sampling path, never the tissue label
     assert (rows["tiling_status"] == "success").all()
+
+
+def test_tile_slides_sampling_progress_counts_slides_not_artifacts(monkeypatch, tmp_path):
+    """Slide-completion progress must track slides, not per-annotation artifacts: a 2-slide ×
+    3-annotation run reports completed=2/total=2, never completed=6."""
+    _patch_tile_slides_open(monkeypatch)
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        orchmod, "emit_progress", lambda name, **kw: events.append((name, kw))
+    )
+    tile_slides(
+        _slides(2),
+        tiling=_mock_tiling(),
+        filtering=FilterConfig(a_t=0),
+        output_dir=tmp_path,
+        num_workers=1,
+        sampling=_sampling_spec(),
+        selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+    )
+    progress = [kw for name, kw in events if name == "tiling.progress"]
+    assert progress, "expected tiling.progress events"
+    assert all(p["total"] == 2 for p in progress)
+    assert max(p["completed"] for p in progress) == 2
+    assert all(p["completed"] <= p["total"] for p in progress)
 
 
 def test_tile_slides_single_output_emits_one_artifact_per_slide(monkeypatch, tmp_path):

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -533,6 +533,9 @@ def test_tile_slides_single_output_emits_one_artifact_per_slide(monkeypatch, tmp
     assert set(rows["sample_id"]) == {"slide0", "slide1"}
     assert (rows["tiling_status"] == "success").all()
     assert (rows["num_tiles"] > 0).all()
+    # Merged single-output rows must be distinguishable from binary tissue tiling.
+    assert set(rows["annotation"]) == {"merged"}
+    assert (rows["output_mode"] == CoordinateOutputMode.SINGLE_OUTPUT).all()
 
 
 def test_tile_slides_sampling_rejects_unsupported_combos(monkeypatch, tmp_path):

--- a/tests/test_annotation_path_safety.py
+++ b/tests/test_annotation_path_safety.py
@@ -1,0 +1,24 @@
+"""The annotation label → tiles directory boundary must reject path-traversal labels for
+every caller (the public tile_slides(sampling=...) API bypasses config-level validation)."""
+
+from pathlib import Path
+
+import pytest
+
+from hs2p.artifacts import _annotation_tiles_dir
+
+
+def test_annotation_tiles_dir_flat_layout_for_none_and_tissue(tmp_path):
+    base = tmp_path / "tiles"
+    assert _annotation_tiles_dir(tmp_path, None) == base
+    assert _annotation_tiles_dir(tmp_path, "tissue") == base
+
+
+def test_annotation_tiles_dir_subdir_for_named_class(tmp_path):
+    assert _annotation_tiles_dir(tmp_path, "grade_4") == tmp_path / "tiles" / "grade_4"
+
+
+@pytest.mark.parametrize("bad", ["../outside", "/tmp/owned", "a/b", "..", ".", "x\\y", ""])
+def test_annotation_tiles_dir_rejects_traversal(tmp_path, bad):
+    with pytest.raises(ValueError, match="path component"):
+        _annotation_tiles_dir(tmp_path, bad)

--- a/tests/test_sampling_color_mapping_validation.py
+++ b/tests/test_sampling_color_mapping_validation.py
@@ -1,6 +1,28 @@
 import pytest
 
-from hs2p.configs.resolvers import validate_color_mapping
+from hs2p.configs.resolvers import validate_color_mapping, validate_pixel_mapping
+
+
+def test_validate_pixel_mapping_accepts_uint16_labels_without_background():
+    # background is optional, and values up to the uint16 ceiling are allowed
+    validate_pixel_mapping({"grade_4": 300, "grade_5": 600})
+
+
+def test_validate_pixel_mapping_rejects_duplicate_values():
+    with pytest.raises(ValueError, match="unique"):
+        validate_pixel_mapping({"background": 0, "tumor": 1, "stroma": 1})
+
+
+def test_validate_pixel_mapping_rejects_out_of_range_values():
+    with pytest.raises(ValueError, match="range"):
+        validate_pixel_mapping({"background": 0, "tumor": 70000})
+    with pytest.raises(ValueError, match="range"):
+        validate_pixel_mapping({"background": 0, "tumor": -1})
+
+
+def test_validate_pixel_mapping_rejects_non_integer_values():
+    with pytest.raises(ValueError, match="integer"):
+        validate_pixel_mapping({"background": 0, "tumor": 1.5})
 
 
 def test_validation_accepts_omegaconf_listconfig_rgb_values():

--- a/tests/test_sampling_color_mapping_validation.py
+++ b/tests/test_sampling_color_mapping_validation.py
@@ -25,6 +25,13 @@ def test_validate_pixel_mapping_rejects_non_integer_values():
         validate_pixel_mapping({"background": 0, "tumor": 1.5})
 
 
+@pytest.mark.parametrize("bad", ["../escape", "/tmp/owned", "a/b", "..", ".", "x\\y", ""])
+def test_validate_pixel_mapping_rejects_unsafe_label_names(bad):
+    # label names become output path components, so traversal/separators must be rejected
+    with pytest.raises(ValueError, match="path component"):
+        validate_pixel_mapping({"background": 0, bad: 1})
+
+
 def test_validation_accepts_omegaconf_listconfig_rgb_values():
     omegaconf = pytest.importorskip("omegaconf")
     list_config = omegaconf.ListConfig([243, 229, 171])

--- a/tests/test_sampling_request_resolution.py
+++ b/tests/test_sampling_request_resolution.py
@@ -1,0 +1,78 @@
+"""CLI wiring for annotation sampling: resolve_sampling_request decides binary-tissue vs
+annotation sampling from the merged config, resolve_output_mode validates the mode, and
+resolve_tiling_config tolerates configs that declare no 'tissue' threshold."""
+
+import pytest
+from omegaconf import OmegaConf
+
+from hs2p.configs.loader import default_config
+from hs2p.configs.resolvers import (
+    resolve_output_mode,
+    resolve_sampling_request,
+    resolve_tiling_config,
+)
+from hs2p.wsi.types import CoordinateOutputMode, CoordinateSelectionStrategy
+
+
+def _cfg(overrides: dict | None = None):
+    cfg = OmegaConf.create(default_config)
+    if overrides:
+        cfg = OmegaConf.merge(cfg, OmegaConf.create(overrides))
+    return cfg
+
+
+def test_default_config_routes_to_binary_tissue():
+    cfg = _cfg()
+    tiling = resolve_tiling_config(cfg)
+    sampling, strategy, output_mode = resolve_sampling_request(cfg, tiling=tiling)
+    assert sampling is None and strategy is None and output_mode is None
+    assert tiling.tissue_threshold == 0.01
+
+
+def test_annotation_config_triggers_sampling_without_tissue_threshold():
+    cfg = _cfg(
+        {
+            "tiling": {
+                "masks": {
+                    "output_mode": "single_output",
+                    "pixel_mapping": {"grade_4": 4, "grade_5": 5},
+                    "colors": {"grade_4": [255, 0, 0], "grade_5": [0, 0, 255]},
+                    # null out the default tissue threshold → pure-grade sampling
+                    "min_coverage": {"tissue": None, "grade_4": 0.25, "grade_5": 0.25},
+                }
+            }
+        }
+    )
+    # No 'tissue' threshold must not raise here (it used to KeyError).
+    tiling = resolve_tiling_config(cfg)
+    assert tiling.tissue_threshold == 0.0
+
+    sampling, strategy, output_mode = resolve_sampling_request(cfg, tiling=tiling)
+    assert sampling is not None
+    assert set(sampling.active_annotations) == {"grade_4", "grade_5"}
+    assert strategy == CoordinateSelectionStrategy.JOINT_SAMPLING
+    assert output_mode == CoordinateOutputMode.SINGLE_OUTPUT
+
+
+def test_independent_sampling_flag_selects_strategy():
+    cfg = _cfg(
+        {
+            "tiling": {
+                "independent_sampling": True,
+                "masks": {
+                    "pixel_mapping": {"grade_4": 4, "grade_5": 5},
+                    "colors": {"grade_4": [255, 0, 0], "grade_5": [0, 0, 255]},
+                    "min_coverage": {"tissue": None, "grade_4": 0.25, "grade_5": 0.25},
+                },
+            }
+        }
+    )
+    tiling = resolve_tiling_config(cfg)
+    _, strategy, _ = resolve_sampling_request(cfg, tiling=tiling)
+    assert strategy == CoordinateSelectionStrategy.INDEPENDENT_SAMPLING
+
+
+def test_resolve_output_mode_default_and_validation():
+    assert resolve_output_mode(_cfg()) == CoordinateOutputMode.PER_ANNOTATION
+    with pytest.raises(ValueError, match="output_mode"):
+        resolve_output_mode(_cfg({"tiling": {"masks": {"output_mode": "bogus"}}}))

--- a/tests/test_sampling_request_resolution.py
+++ b/tests/test_sampling_request_resolution.py
@@ -72,6 +72,45 @@ def test_independent_sampling_flag_selects_strategy():
     assert strategy == CoordinateSelectionStrategy.INDEPENDENT_SAMPLING
 
 
+def test_label_reusing_value_one_works_when_default_tissue_is_nulled():
+    """Configs deep-merge over the default {background:0, tissue:1}; nulling the tissue pixel
+    value drops it so a 0/1 annotation mask (tumor:1) configures without a duplicate-value error."""
+    cfg = _cfg(
+        {
+            "tiling": {
+                "masks": {
+                    "pixel_mapping": {"tissue": None, "tumor": 1},
+                    "colors": {"tissue": None, "tumor": [1, 2, 3]},
+                    "min_coverage": {"tissue": None, "tumor": 0.5},
+                }
+            }
+        }
+    )
+    sampling, _, _ = resolve_sampling_request(cfg, tiling=resolve_tiling_config(cfg))
+    assert sampling is not None
+    assert dict(sampling.pixel_mapping) == {"background": 0, "tumor": 1}
+    assert set(sampling.active_annotations) == {"tumor"}
+
+
+def test_background_label_is_not_reserved_at_activation():
+    """No label name is special at the CLI activation boundary: a thresholded 'background'
+    class enables annotation sampling instead of falling through to binary tissue."""
+    cfg = _cfg(
+        {
+            "tiling": {
+                "masks": {
+                    "pixel_mapping": {"tissue": None},
+                    "colors": {"tissue": None},
+                    "min_coverage": {"tissue": None, "background": 0.5},
+                }
+            }
+        }
+    )
+    sampling, _, _ = resolve_sampling_request(cfg, tiling=resolve_tiling_config(cfg))
+    assert sampling is not None
+    assert set(sampling.active_annotations) == {"background"}
+
+
 def test_resolve_output_mode_default_and_validation():
     assert resolve_output_mode(_cfg()) == CoordinateOutputMode.PER_ANNOTATION
     with pytest.raises(ValueError, match="output_mode"):

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -2290,6 +2290,7 @@ def test_tile_slides_writes_process_list_and_can_reuse_precomputed_tiles(
     assert list(process_df.columns) == [
         "sample_id",
         "annotation",
+        "output_mode",
         "image_path",
         "mask_path",
         "requested_backend",

--- a/tests/test_unified_joint_sampling.py
+++ b/tests/test_unified_joint_sampling.py
@@ -100,6 +100,20 @@ def test_joint_sampling_returns_key_per_active_annotation():
     assert set(results.keys()) == {"tumor", "stroma"}
 
 
+def test_invalid_output_mode_fails_fast():
+    """An unrecognized output_mode (e.g. an API typo) must raise, not silently fall through
+    to per-annotation output."""
+    with pytest.raises(ValueError, match="output_mode"):
+        build_per_annotation_tiling_results(
+            slide=_mock_slide(),
+            resolved_masks=_resolved_masks(_nonoverlapping_annotation_mask()),
+            sampling_spec=_sampling_spec(),
+            selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+            output_mode="bogus_mode",
+            **_COMMON_KWARGS,
+        )
+
+
 def test_joint_sampling_annotation_field_on_result():
     """Each TilingResult.annotation matches its dict key."""
     results = build_per_annotation_tiling_results(

--- a/tests/test_unified_process_list_schema.py
+++ b/tests/test_unified_process_list_schema.py
@@ -44,13 +44,41 @@ def test_success_row_annotation_preserved_when_set():
     assert row["annotation"] == "tumor"
 
 
+def test_single_output_row_labeled_merged_not_tissue():
+    """A merged SINGLE_OUTPUT artifact has annotation=None like binary tissue, but must not be
+    recorded as 'tissue' — it carries output_mode=single_output and the label 'merged'."""
+    from hs2p.wsi.types import CoordinateOutputMode
+
+    artifact = TilingArtifacts(
+        sample_id="slide-1",
+        coordinates_npz_path=Path("tiles/slide-1.coordinates.npz"),
+        coordinates_meta_path=Path("tiles/slide-1.coordinates.meta.json"),
+        num_tiles=5,
+        annotation=None,
+        output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+    )
+    row = orchestration_mod._build_success_process_row(
+        whole_slide=_whole_slide(), artifact=artifact
+    )
+    assert row["annotation"] == "merged"
+    assert row["output_mode"] == CoordinateOutputMode.SINGLE_OUTPUT
+
+
+def test_binary_tissue_row_has_no_output_mode():
+    row = orchestration_mod._build_success_process_row(
+        whole_slide=_whole_slide(), artifact=_artifact(annotation=None)
+    )
+    assert row["annotation"] == "tissue"
+    assert row["output_mode"] is None
+
+
 def test_success_row_has_all_required_columns():
     row = orchestration_mod._build_success_process_row(
         whole_slide=_whole_slide(mask_path=Path("mask.png")),
         artifact=_artifact(annotation="tissue"),
     )
     expected_columns = {
-        "sample_id", "annotation", "image_path", "mask_path",
+        "sample_id", "annotation", "output_mode", "image_path", "mask_path",
         "requested_backend", "backend", "tiling_status", "num_tiles",
         "coordinates_npz_path", "coordinates_meta_path", "tiles_tar_path",
         "mask_preview_path", "tiling_preview_path",
@@ -66,7 +94,7 @@ def test_failure_row_has_all_required_columns():
         traceback_text="traceback",
     )
     expected_columns = {
-        "sample_id", "annotation", "image_path", "mask_path",
+        "sample_id", "annotation", "output_mode", "image_path", "mask_path",
         "requested_backend", "backend", "tiling_status", "num_tiles",
         "coordinates_npz_path", "coordinates_meta_path", "tiles_tar_path",
         "mask_preview_path", "tiling_preview_path",


### PR DESCRIPTION
Foundation in hs2p for soma's slide-manifest segmentation ingestion (slides + annotation masks → sampled ROIs). Bottom of a 3-repo stack: **hs2p → slide2vec → soma**.

## What's here (by slice)
- **A1 — annotation-mask producer + coverage.** `resolve_annotation_masks` (splits a label raster into per-class binaries at `seg_downsample` — the missing `ResolvedAnnotationMasks` producer) and `summarize_annotation_coverage` (per-class `area_mm2`/`frac`/`est_tiles`), on `hs2p.api`/`hs2p.preprocessing`. Plus an openslide retry when cucim mis-decodes intermediate pyramid levels of compressed single-channel masks.
- **H1 — wire sampling into the public API.** `tile_slide`/`tile_slides` accept `sampling=`/`selection_strategy=`/`output_mode=` and route through a shared `_run_per_annotation` core; `tile_slides` fans out to one artifact per (slide, annotation). Deferred combos (`resume`/`read_coordinates_from`/`save_tiles`/`preview`) guarded. Tissue path unchanged.
- **S1 — SINGLE_OUTPUT merge.** `build_per_annotation_tiling_results` collapses to `{None: merged}` for `output_mode=SINGLE_OUTPUT` (dedup'd union of tiles passing any class threshold, max per-class coverage) → each spatial tile encoded once for dense segmentation, one artifact/row per slide.
- **A3a — ROI mask reads.** `read_label_region_at_spacing` (region counterpart of `read_label_at_spacing`; nearest + channel-collapse via a shared `_collapse_label_raster`).
- **CLI — config-driven sampling.** The `hs2p` entrypoint resolves a `SamplingSpec` from `tiling.masks` and routes it through `tile_slides`. Annotation sampling activates when `pixel_mapping` is customized away from the default `{background, tissue}`; per-slide annotation masks come from the CSV `mask_path` column. New `tiling.masks.output_mode` (`per_annotation`/`single_output`); `tiling.independent_sampling` selects independent vs joint. `resume`/`read_coordinates_from`/`save_tiles` raise a clear error with annotation sampling; previews are skipped. Binary tissue tiling is the default and is unchanged.
- **Hardening (review-driven).** No reserved label name — `pixel_mapping` is fully user-owned (null a label's pixel value to drop a deep-merged default, e.g. to reuse value `1`); upfront `validate_pixel_mapping` (distinct, in-range, safe single path-component labels); lossless `uint16` label reads (validated labels above 255 no longer wrap to `uint8`); path-traversal guard at the artifact sink so labels can't escape `output_dir/tiles`; `output_mode` recorded in `process_list.csv` so merged single-output rows aren't mistaken for tissue; per-slide (not per-artifact) progress counting; openslide fallback also recovers when the primary read raises.

## Tests
Full suite green (**270 passed, 3 skipped**). Beyond the original producer/coverage/JOINT/INDEPENDENT/SINGLE_OUTPUT coverage, adds tests for the CLI sampling resolver (`resolve_sampling_request`/`resolve_output_mode`, deep-merge null-to-drop, `background`-not-reserved activation), label safety + path-traversal rejection, `uint16` label preservation, the openslide fallback edge cases, and single-output process-list labeling.

## Release
No version bump in this PR — cut via `release.py --level minor` (`4.0.8 → 4.1.0`, new public APIs) from `main` after merge.

## Related (soma repo)
Implements the hs2p half of clemsgrs/soma#82 (S1) and clemsgrs/soma#84 (A3a); also the A1/H1 foundation under clemsgrs/soma#81. The soma PR (last in the stack) closes those issues.
