### PR TITLE
refactor(annotation): shared annotation→path flattening helper for artifact and preview paths

### DIFF
--- a/hs2p/artifacts.py
+++ b/hs2p/artifacts.py
@@ -14,7 +14,7 @@ from hs2p.preprocessing import (
     _load_tiling_result_from_paths,
     _save_tiling_result,
 )
-from hs2p.fileops import promote_temp_file
+from hs2p.fileops import is_flattened_annotation, promote_temp_file
 
 
 @dataclass(frozen=True)
@@ -113,7 +113,7 @@ def _ensure_safe_path_component(name: str) -> str:
 def _annotation_tiles_dir(output_dir: Path, annotation: str | None) -> Path:
     """Return the tiles sub-directory, collapsing 'tissue' to the flat layout."""
     base = Path(output_dir) / "tiles"
-    if annotation is None or annotation == "tissue":
+    if is_flattened_annotation(annotation):
         return base
     return base / _ensure_safe_path_component(annotation)
 

--- a/hs2p/fileops.py
+++ b/hs2p/fileops.py
@@ -5,6 +5,19 @@ import shutil
 from pathlib import Path
 
 
+def is_flattened_annotation(annotation: str | None) -> bool:
+    """Decide whether an annotation's artifacts land at the flat output root.
+
+    This is the single source of truth for the annotation→path rule shared by the
+    coordinate/tar artifact code and the preview/visualization layer: ``None`` and the
+    sentinel ``"tissue"`` label collapse to the flat layout (no per-annotation subdir),
+    while every other label gets its own ``.../{annotation}/...`` location. It lives in
+    this leaf module (stdlib-only deps) so both layers can import it without a circular
+    import and a preview file can never land in a different place than its coordinate set.
+    """
+    return annotation is None or annotation == "tissue"
+
+
 def promote_temp_file(temp_path: Path, target_path: Path) -> None:
     """Move a completed temp file into place, with a CIFS-friendly fallback."""
     try:

--- a/hs2p/tiling/tar.py
+++ b/hs2p/tiling/tar.py
@@ -14,13 +14,13 @@ from PIL import Image
 
 from hs2p.tiling.result import TilingResult
 from hs2p.tile_qc import filter_coordinate_tiles, needs_pixel_qc
-from hs2p.fileops import promote_temp_file
+from hs2p.fileops import is_flattened_annotation, promote_temp_file
 from hs2p.wsi import iter_tile_records_from_result, open_reader_for_result
 from hs2p.wsi.reader import BatchRegionReader
 
 
 def _annotation_tar_stem(sample_id: str, annotation: str | None) -> str:
-    if annotation is None or annotation == "tissue":
+    if is_flattened_annotation(annotation):
         return f"{sample_id}.tiles"
     return f"{sample_id}.{annotation}.tiles"
 

--- a/tests/test_annotation_path_flattening.py
+++ b/tests/test_annotation_path_flattening.py
@@ -1,0 +1,40 @@
+"""The annotation→path flattening rule (None/tissue → flat root, other labels → a
+per-annotation subdir) must live in a single shared helper that both the artifact code
+and the preview/visualization layer can import without a circular import."""
+
+import pytest
+
+from hs2p.fileops import is_flattened_annotation
+
+
+@pytest.mark.parametrize("annotation", [None, "tissue"])
+def test_flattened_for_none_and_tissue(annotation):
+    assert is_flattened_annotation(annotation) is True
+
+
+@pytest.mark.parametrize("annotation", ["grade_4", "tumor", "Tissue", "tissue_x"])
+def test_not_flattened_for_named_labels(annotation):
+    assert is_flattened_annotation(annotation) is False
+
+
+def test_helper_importable_without_circular_import():
+    # fileops is a leaf module (stdlib-only deps), so importing the helper from it
+    # cannot pull in artifacts or the preview layer.
+    import hs2p.fileops as fileops
+
+    assert hasattr(fileops, "is_flattened_annotation")
+
+
+def test_artifact_dir_uses_shared_helper():
+    from hs2p.artifacts import _annotation_tiles_dir
+
+    # When flattened, no per-annotation subdir is appended.
+    assert is_flattened_annotation(None)
+    assert _annotation_tiles_dir("/out", "tissue") == _annotation_tiles_dir("/out", None)
+
+
+def test_tar_stem_uses_shared_helper():
+    from hs2p.tiling.tar import _annotation_tar_stem
+
+    assert _annotation_tar_stem("s", None) == _annotation_tar_stem("s", "tissue")
+    assert _annotation_tar_stem("s", "grade_4") == "s.grade_4.tiles"


### PR DESCRIPTION
## Summary

Pure refactor (no behavior change). Extracts the duplicated annotation→path flattening rule — `annotation in {None, "tissue"}` collapses to the flat tiles root, every other label gets its own `.../{annotation}/...` subdirectory — into a single shared helper `is_flattened_annotation` in `hs2p/fileops.py`.

`hs2p/fileops.py` is a leaf module (stdlib-only deps) that both the artifact code and the follow-up preview/visualization layer can import without a circular import, guaranteeing a preview file can never land in a different place than the coordinate set it corresponds to.

## Changes
- `hs2p/fileops.py`: new `is_flattened_annotation(annotation)` — single source of truth for the rule.
- `hs2p/artifacts.py`: `_annotation_tiles_dir` now calls the helper instead of its own `annotation is None or annotation == "tissue"` copy.
- `hs2p/tiling/tar.py`: `_annotation_tar_stem` switched over likewise.
- `tests/test_annotation_path_flattening.py`: focused unit test for the helper and that both callers route through it.

## Acceptance criteria
- [x] A single shared helper encodes the annotation→subdirectory flattening rule (None/tissue → flat root, other labels → per-annotation subdir).
- [x] The existing coordinate and tar artifact code uses the shared helper rather than its own copy of the rule.
- [x] No change to any emitted artifact path — existing artifact/manifest tests pass unchanged.
- [x] The helper is importable by the preview layer (placed in `hs2p/fileops.py`, a leaf module with no circular-import risk).

## Tests
Full suite: 276 passed, 3 skipped, 44 deselected (integration/script). Prior-art gate (`test_fixture_artifacts_regression`, `test_unified_process_list_schema`, `test_unified_independent_sampling`, `test_unified_joint_sampling`): 27 passed, byte-for-byte unchanged on emitted paths.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
