### PR TITLE
Annotation previews: multi-label mask preview, end-to-end

### DIFF
--- a/hs2p/__main__.py
+++ b/hs2p/__main__.py
@@ -88,8 +88,9 @@ def main(args):
             )
             if sampling is not None:
                 # Annotation sampling does not yet support these features; refuse explicit
-                # opt-ins rather than silently ignoring them, and skip previews (which default
-                # on) with a clear notice instead of erroring on every run.
+                # opt-ins rather than silently ignoring them. Previews are supported (the
+                # multi-label mask preview); only tiling previews are still absent, which
+                # tile_slides tolerates without erroring.
                 unsupported = [
                     name
                     for name, enabled in (
@@ -109,12 +110,8 @@ def main(args):
                     selection_strategy=selection_strategy,
                     output_mode=output_mode,
                     active_annotations=list(sampling.active_annotations),
-                    previews_skipped=bool(
-                        preview.save_mask_preview or preview.save_tiling_preview
-                    ),
                 )
                 tile_kwargs.update(
-                    preview=None,
                     resume=False,
                     read_coordinates_from=None,
                     save_tiles=False,

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -17,6 +17,7 @@ from hs2p.configs import FilterConfig, PreviewConfig, SegmentationConfig, Tiling
 from hs2p.progress import emit_progress, emit_progress_log
 from hs2p.tiling.result import ResolvedTissueMask, TilingResult
 from hs2p.tiling.single import (
+    MaskPreviewRequest,
     build_tiling_result_from_mask,
     preprocess_slide,
     preprocess_slide_per_annotation,
@@ -257,6 +258,7 @@ def _run_per_annotation(
     output_mode: str,
     seg_downsample: int,
     num_workers: int,
+    mask_preview: "MaskPreviewRequest | None" = None,
 ) -> "dict[str, TilingResult]":
     """Shared annotation-sampling compute, called identically by ``tile_slide`` and the
     ``tile_slides`` worker so the two paths never diverge. Resolves the annotation mask and
@@ -295,6 +297,7 @@ def _run_per_annotation(
         qc_spacing_um=filtering.qc_spacing_um,
         num_workers=num_workers,
         output_mode=output_mode,
+        mask_preview=mask_preview,
     )
 
 
@@ -685,7 +688,11 @@ def _finalize_pending_tiling_preview(
 
 
 def _save_per_annotation_artifact(
-    result: TilingResult, *, output_dir: Path, annotation: str | None
+    result: TilingResult,
+    *,
+    output_dir: Path,
+    annotation: str | None,
+    mask_preview_path: Path | None = None,
 ) -> TilingArtifacts:
     artifact = save_tiling_result(result, output_dir=output_dir, annotation=annotation)
     return TilingArtifacts(
@@ -694,7 +701,8 @@ def _save_per_annotation_artifact(
         coordinates_meta_path=artifact.coordinates_meta_path,
         num_tiles=artifact.num_tiles,
         tiles_tar_path=None,
-        mask_preview_path=artifact.mask_preview_path,
+        # One slide-level preview, repeated on every label row so each row is self-describing.
+        mask_preview_path=mask_preview_path,
         tiling_preview_path=artifact.tiling_preview_path,
         backend=artifact.backend,
         requested_backend=artifact.requested_backend,
@@ -705,11 +713,24 @@ def _save_per_annotation_artifact(
 
 def _compute_and_save_per_annotation(request: _ComputeRequest) -> _ComputeResponse:
     """Compute + persist one TilingResult per active annotation, via the shared
-    ``_run_per_annotation`` core (same compute path as ``tile_slide``)."""
+    ``_run_per_annotation`` core (same compute path as ``tile_slide``).
+
+    Renders one multi-label mask preview per slide (when requested) at the conventional flat
+    ``preview/mask/{sample_id}.jpg`` location, then stamps that path onto every label row of
+    the slide so each row is self-describing.
+    """
     effective_segmentation = _resolve_effective_segmentation(
         whole_slide=request.whole_slide,
         segmentation=request.segmentation,
     )
+    mask_preview = None
+    if request.mask_preview_path is not None:
+        mask_preview = MaskPreviewRequest(
+            mask_preview_path=request.mask_preview_path,
+            color_mapping=getattr(request.sampling, "color_mapping", None),
+            downsample=request.preview_downsample,
+            alpha=request.mask_overlay_alpha,
+        )
     results = _run_per_annotation(
         whole_slide=request.whole_slide,
         tiling=request.tiling,
@@ -724,10 +745,20 @@ def _compute_and_save_per_annotation(request: _ComputeRequest) -> _ComputeRespon
         ),
         seg_downsample=effective_segmentation.downsample,
         num_workers=request.num_workers,
+        mask_preview=mask_preview,
+    )
+    mask_preview_path = (
+        request.mask_preview_path
+        if request.mask_preview_path is not None
+        and request.mask_preview_path.is_file()
+        else None
     )
     artifacts = [
         _save_per_annotation_artifact(
-            result, output_dir=request.output_dir, annotation=annotation
+            result,
+            output_dir=request.output_dir,
+            annotation=annotation,
+            mask_preview_path=mask_preview_path,
         )
         for annotation, result in results.items()
     ]
@@ -740,7 +771,7 @@ def _compute_and_save_per_annotation(request: _ComputeRequest) -> _ComputeRespon
         result=None,
         requested_backend=request.tiling.requested_backend,
         backend=request.tiling.backend,
-        mask_preview_path=None,
+        mask_preview_path=mask_preview_path,
     )
 
 
@@ -995,7 +1026,6 @@ def tile_slides(
                 ("resume", resume),
                 ("read_coordinates_from", read_coordinates_from is not None),
                 ("save_tiles", save_tiles),
-                ("preview", preview is not None),
             )
             if active
         ]
@@ -1417,11 +1447,12 @@ def tile_slides(
                 artifact=artifact,
             )
         )
-        # Annotation sampling emits one extra artifact per additional active annotation.
+        # Annotation sampling emits one extra artifact per additional active annotation. Each
+        # carries the same slide-level mask preview so every label row repeats it.
         for extra in getattr(response, "extra_artifacts", ()):
             extra_artifact = _build_success_artifact(
                 base_artifact=extra,
-                mask_preview_path=None,
+                mask_preview_path=extra.mask_preview_path,
                 tiling_preview_path=None,
             )
             _record_tiling_success(

--- a/hs2p/tiling/single.py
+++ b/hs2p/tiling/single.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -15,6 +15,45 @@ from hs2p.tiling.mask import resolve_annotation_masks, resolve_tissue_mask
 from hs2p.tile_qc import filter_coordinate_tiles, needs_pixel_qc
 from hs2p.wsi.reader import open_slide
 from hs2p.wsi.types import CoordinateOutputMode, CoordinateSelectionStrategy
+from hs2p.wsi.visualization import _combine_label_masks, save_overlay_preview
+
+
+@dataclass(frozen=True)
+class MaskPreviewRequest:
+    """Where and how to render the per-slide multi-label annotation mask preview."""
+
+    mask_preview_path: Path
+    color_mapping: dict[str, list[int] | None] | None
+    downsample: int = 32
+    alpha: float = 0.5
+
+
+def _render_annotation_mask_preview(
+    *,
+    request: MaskPreviewRequest,
+    resolved_masks: ResolvedAnnotationMasks,
+    image_path: str | Path,
+    backend: str,
+) -> None:
+    """Render one filled, semi-transparent multi-label overlay from the *resolved* per-label
+    binary masks (never a re-read of the raw mask file), once per slide. Labels with a null
+    color are omitted by the shared palette/alpha builders."""
+    if request.color_mapping is None:
+        return
+    label_arr = _combine_label_masks(
+        masks=resolved_masks.masks,
+        pixel_mapping=resolved_masks.pixel_mapping,
+    )
+    save_overlay_preview(
+        wsi_path=Path(image_path),
+        backend=backend,
+        mask_arr=label_arr,
+        mask_preview_path=Path(request.mask_preview_path),
+        downsample=request.downsample,
+        pixel_mapping=dict(resolved_masks.pixel_mapping),
+        color_mapping=dict(request.color_mapping),
+        alpha=request.alpha,
+    )
 
 
 def build_tiling_result_from_mask(
@@ -684,6 +723,7 @@ def preprocess_slide_per_annotation(
     qc_spacing_um: float = 2.0,
     num_workers: int = 1,
     output_mode: str | None = None,
+    mask_preview: MaskPreviewRequest | None = None,
 ) -> "dict[str, TilingResult]":
     """Annotation-aware tiling: open the slide, resolve its annotation mask into per-class
     binaries (:func:`resolve_annotation_masks`), then sample per active annotation.
@@ -693,6 +733,9 @@ def preprocess_slide_per_annotation(
     result, wiring the previously-orphaned :func:`build_per_annotation_tiling_results` to a
     real mask. ``selection_strategy`` selects INDEPENDENT vs JOINT sampling; ``output_mode``
     selects single vs per-annotation coordinate output.
+
+    When ``mask_preview`` is given, one filled multi-label overlay is rendered here — once per
+    slide, from the just-resolved per-label binary masks — before any sampling.
     """
     slide = open_slide(image_path, backend=backend, spacing_override=spacing_override)
     try:
@@ -702,6 +745,13 @@ def preprocess_slide_per_annotation(
             pixel_mapping=pixel_mapping,
             seg_downsample=seg_downsample,
         )
+        if mask_preview is not None:
+            _render_annotation_mask_preview(
+                request=mask_preview,
+                resolved_masks=resolved_masks,
+                image_path=image_path,
+                backend=slide.backend_name,
+            )
         return build_per_annotation_tiling_results(
             slide=slide,
             resolved_masks=resolved_masks,
@@ -737,6 +787,7 @@ def preprocess_slide_per_annotation(
 
 
 __all__ = [
+    "MaskPreviewRequest",
     "build_per_annotation_tiling_results",
     "build_tiling_result_from_mask",
     "preprocess_slide",

--- a/hs2p/wsi/__init__.py
+++ b/hs2p/wsi/__init__.py
@@ -18,6 +18,7 @@ from .visualization import (
     DEFAULT_TISSUE_COLOR_MAPPING,
     DEFAULT_TISSUE_PIXEL_MAPPING,
     overlay_mask_on_slide,
+    render_annotation_mask_preview,
     save_overlay_preview,
     write_coordinate_preview,
 )

--- a/hs2p/wsi/visualization.py
+++ b/hs2p/wsi/visualization.py
@@ -143,6 +143,63 @@ def _resolve_fill_overlay_style(
     return palette, pixel_mapping, color_mapping
 
 
+def _combine_label_masks(
+    *,
+    masks: dict[str, np.ndarray],
+    pixel_mapping: dict[str, int],
+) -> np.ndarray:
+    """Recompose a single discrete label raster from per-label binary masks.
+
+    The annotation sampler consumes one binary (255 fg / 0 bg) mask per label; the filled
+    multi-label overlay needs them back as one raster carrying each label's declared pixel
+    value. Labels are painted in ``pixel_mapping`` order; later labels win on overlap, matching
+    how a single declared raster would have stored them.
+    """
+    reference = next(iter(masks.values()))
+    combined = np.zeros(reference.shape[:2], dtype=np.uint8)
+    for name, value in pixel_mapping.items():
+        binary = masks.get(name)
+        if binary is None:
+            continue
+        combined = np.where(np.asarray(binary) > 0, np.uint8(int(value)), combined).astype(
+            np.uint8
+        )
+    return combined
+
+
+def render_annotation_mask_preview(
+    *,
+    wsi_path: Path,
+    backend: str,
+    masks: dict[str, np.ndarray],
+    pixel_mapping: dict[str, int],
+    color_mapping: dict[str, list[int] | None] | None,
+    mask_preview_path: Path,
+    downsample: int = 32,
+    alpha: float = 0.5,
+) -> None:
+    """Write one filled, semi-transparent multi-label overlay of the resolved annotation masks.
+
+    Rebuilds a discrete label raster from the *resolved* per-label binary masks (never a
+    re-read of the raw mask file) and renders it through the shared filled-overlay path. Each
+    label is colored from ``color_mapping``; labels with a null color are omitted (the palette
+    and alpha builders skip them).
+    """
+    if color_mapping is None:
+        return
+    label_arr = _combine_label_masks(masks=masks, pixel_mapping=pixel_mapping)
+    save_overlay_preview(
+        wsi_path=Path(wsi_path),
+        backend=backend,
+        mask_arr=label_arr,
+        mask_preview_path=Path(mask_preview_path),
+        downsample=downsample,
+        pixel_mapping=dict(pixel_mapping),
+        color_mapping=dict(color_mapping),
+        alpha=alpha,
+    )
+
+
 def save_overlay_preview(
     *,
     wsi_path: Path,

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -2,6 +2,7 @@
 coverage summary (summarize_annotation_coverage) — the previously-missing keystone for
 build_per_annotation_tiling_results, plus the coverage utility soma's ingestion drives."""
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -574,9 +575,15 @@ def test_tile_slides_single_output_emits_one_artifact_per_slide(monkeypatch, tmp
     assert (rows["output_mode"] == CoordinateOutputMode.SINGLE_OUTPUT).all()
 
 
-def test_tile_slides_sampling_rejects_unsupported_combos(monkeypatch, tmp_path):
+@pytest.mark.parametrize("unsupported", ["resume", "read_coordinates_from", "save_tiles"])
+def test_tile_slides_sampling_rejects_unsupported_combos(monkeypatch, tmp_path, unsupported):
     _patch_tile_slides_open(monkeypatch)
-    with pytest.raises(NotImplementedError, match="resume"):
+    kwargs = {
+        "resume": {"resume": True},
+        "read_coordinates_from": {"read_coordinates_from": tmp_path},
+        "save_tiles": {"save_tiles": True},
+    }[unsupported]
+    with pytest.raises(NotImplementedError, match=unsupported):
         tile_slides(
             _slides(1),
             tiling=_mock_tiling(),
@@ -584,8 +591,94 @@ def test_tile_slides_sampling_rejects_unsupported_combos(monkeypatch, tmp_path):
             output_dir=tmp_path,
             num_workers=1,
             sampling=_sampling_spec(),
-            resume=True,
+            **kwargs,
         )
+
+
+def _sampling_spec_with_colors():
+    return SamplingSpec(
+        pixel_mapping=PIXEL_MAPPING,
+        color_mapping={
+            "background": None,
+            "tumor": [255, 0, 0],
+            "stroma": [0, 255, 0],
+            "necrosis": None,  # null color → omitted from the overlay
+        },
+        tissue_percentage={"background": None, "tumor": 0.1, "stroma": 0.1, "necrosis": 0.1},
+        active_annotations=("tumor", "stroma", "necrosis"),
+    )
+
+
+def _patch_mask_preview_renderer(monkeypatch):
+    """Record every annotation mask-preview render and stub the file write so the structural
+    tests need no real WSI. Returns the list of recorded render calls."""
+    calls: list[dict] = []
+
+    def _fake_save_overlay_preview(*, mask_preview_path, **kwargs):
+        calls.append({"mask_preview_path": Path(mask_preview_path), **kwargs})
+        Path(mask_preview_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(mask_preview_path).write_bytes(b"preview")
+
+    monkeypatch.setattr(singlemod, "save_overlay_preview", _fake_save_overlay_preview)
+    return calls
+
+
+@pytest.mark.parametrize(
+    "output_mode",
+    [CoordinateOutputMode.PER_ANNOTATION, CoordinateOutputMode.SINGLE_OUTPUT],
+)
+def test_tile_slides_sampling_writes_one_mask_preview_per_slide(
+    monkeypatch, tmp_path, output_mode
+):
+    from hs2p.configs import PreviewConfig
+
+    _patch_tile_slides_open(monkeypatch)
+    calls = _patch_mask_preview_renderer(monkeypatch)
+    tile_slides(
+        _slides(2),
+        tiling=_mock_tiling(),
+        filtering=FilterConfig(a_t=0),
+        preview=PreviewConfig(save_mask_preview=True),
+        output_dir=tmp_path,
+        num_workers=1,
+        sampling=_sampling_spec_with_colors(),
+        selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+        output_mode=output_mode,
+    )
+    # One preview file per slide at the conventional flat location.
+    for sample_id in ("slide0", "slide1"):
+        assert (tmp_path / "preview" / "mask" / f"{sample_id}.jpg").is_file()
+    # Rendered once per slide, not once per active annotation.
+    assert len(calls) == 2
+    # Filled, alpha-blended, per-label colored overlay from the resolved binaries.
+    for call in calls:
+        assert call["color_mapping"]["tumor"] == [255, 0, 0]
+        assert call["color_mapping"]["necrosis"] is None  # null-color label omitted
+        assert call["alpha"] == PreviewConfig().mask_overlay_alpha
+        assert call["pixel_mapping"] == PIXEL_MAPPING
+
+    rows = pd.read_csv(tmp_path / "process_list.csv")
+    expected = str(tmp_path / "preview" / "mask" / "slide0.jpg")
+    slide0_rows = rows[rows["sample_id"] == "slide0"]
+    assert len(slide0_rows) >= 1
+    # mask_preview_path repeated on every label row of the slide.
+    assert (slide0_rows["mask_preview_path"] == expected).all()
+
+
+def test_tile_slides_sampling_without_preview_writes_no_mask_preview(monkeypatch, tmp_path):
+    _patch_tile_slides_open(monkeypatch)
+    calls = _patch_mask_preview_renderer(monkeypatch)
+    tile_slides(
+        _slides(1),
+        tiling=_mock_tiling(),
+        filtering=FilterConfig(a_t=0),
+        output_dir=tmp_path,
+        num_workers=1,
+        sampling=_sampling_spec_with_colors(),
+        selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+    )
+    assert calls == []
+    assert not (tmp_path / "preview" / "mask").exists()
 
 
 def test_summarize_annotation_coverage_est_tiles_none_without_threshold(patched_mask_open):

--- a/tests/test_overlay_semantics.py
+++ b/tests/test_overlay_semantics.py
@@ -207,6 +207,65 @@ def test_overlay_mask_on_slide_defaults_to_tissue_overlay_style(monkeypatch):
     assert np.any(np.all(overlay_arr == np.array([37, 94, 59], dtype=np.uint8), axis=-1))
 
 
+def test_render_annotation_mask_preview_fills_each_label_and_omits_null_colors(
+    monkeypatch, tmp_path: Path
+):
+    """Visual fixture for the multi-label mask preview: the filled overlay must paint each
+    colored label from the resolved per-label binary masks and omit null-color labels."""
+    slide_arr = np.full((120, 120, 3), 200, dtype=np.uint8)
+
+    class FakeWSI:
+        def __init__(self, path, backend="asap"):
+            del backend
+            self.path = Path(path)
+            self.spacings = [0.5]
+            self.level_dimensions = [(120, 120)]
+            self.level_downsamples = [(1.0, 1.0)]
+
+        def get_best_level_for_downsample_custom(self, downsample):
+            del downsample
+            return 0
+
+        def get_slide(self, level):
+            del level
+            return slide_arr
+
+    monkeypatch.setattr(visualization_mod, "WSI", FakeWSI)
+
+    tumor = np.zeros((120, 120), dtype=np.uint8)
+    tumor[10:40, 10:40] = 255
+    stroma = np.zeros((120, 120), dtype=np.uint8)
+    stroma[60:90, 60:90] = 255
+    necrosis = np.zeros((120, 120), dtype=np.uint8)
+    necrosis[10:40, 80:110] = 255  # null color → must NOT appear in the overlay
+
+    preview_path = tmp_path / "mask" / "slide0.jpg"
+    visualization_mod.render_annotation_mask_preview(
+        wsi_path=Path("fake-wsi.tif"),
+        backend="openslide",
+        masks={"tumor": tumor, "stroma": stroma, "necrosis": necrosis},
+        pixel_mapping={"background": 0, "tumor": 1, "stroma": 2, "necrosis": 3},
+        color_mapping={
+            "background": None,
+            "tumor": [255, 0, 0],
+            "stroma": [0, 255, 0],
+            "necrosis": None,
+        },
+        mask_preview_path=preview_path,
+        downsample=1,
+        alpha=1.0,
+    )
+
+    assert preview_path.is_file()
+    with Image.open(preview_path) as saved:
+        arr = np.array(saved.convert("RGB")).astype(int)
+    # tumor region painted red, stroma painted green (alpha=1.0 → label color, modulo JPEG).
+    assert np.abs(arr[25, 25] - np.array([255, 0, 0])).max() <= 4
+    assert np.abs(arr[75, 75] - np.array([0, 255, 0])).max() <= 4
+    # null-color necrosis is omitted: its region keeps the slide background.
+    assert np.abs(arr[25, 95] - np.array([200, 200, 200])).max() <= 4
+
+
 def test_save_overlay_preview_writes_rgba_overlay_to_jpeg(monkeypatch, tmp_path: Path):
     overlay = Image.fromarray(
         np.array(


### PR DESCRIPTION
Closes #143

## What this does

Re-enables the multi-label MASK preview for annotation-aware sampling runs, end-to-end.

- **CLI** (`hs2p/__main__.py`): no longer forces `preview=None`; the "previews skipped" notice is removed. `resume`, `read_coordinates_from`, and `save_tiles` remain explicitly unsupported.
- **`tile_slides`** annotation sampling drops `preview` from its unsupported set so the preview config reaches the per-annotation compute path.
- The per-annotation compute path renders **one filled, semi-transparent multi-label overlay per slide** at the conventional flat `preview/mask/{sample_id}.jpg` location, inline at the point the annotation masks are resolved (`resolve_annotation_masks`), from the **resolved per-label binary masks** — never a re-read of the raw mask file. Colored per label from `tiling.masks.colors`, opacity from `preview.mask_overlay_alpha`, resolution from `preview.downsample`. Null-color labels are omitted. Computed once per slide, not once per label.
- `mask_preview_path` is populated and repeated on **every label row** of the slide in `process_list.csv`, in both `PER_ANNOTATION` and `SINGLE_OUTPUT` modes.
- Tiling previews stay absent (separate follow-up); enabling the preview config on a sampling run does not error.
- Governed entirely by `preview.save_mask_preview` — no new config keys.

## Tests

- Structural tests at the `tile_slides()` seam assert the mask-preview file is emitted once per slide (both output modes) and that `mask_preview_path` is repeated on every label row; a no-preview case asserts nothing is written. The unsupported-combo test is parametrized over `resume`/`read_coordinates_from`/`save_tiles`.
- A visual fixture (`tests/test_overlay_semantics.py`) pins the rendering: each colored label is filled, alpha-blended, and null-color labels are omitted.

Full default suite: 273 passed, 3 skipped. Integration fixture-regression suite: 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)