### PR TITLE
Rename CoordinateOutputMode.SINGLE_OUTPUT to MERGED (4.2.0)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -119,7 +119,7 @@ pip install "hs2p[all]"
     tissue class from sampling, and set `pixel_mapping.tissue: null` to remove the default
     label entirely (required to reuse its value, e.g. a `tumor: 1` mask).
   - `output_mode` (annotation sampling only): `per_annotation` (default) writes one coordinate
-    artifact per sampled class; `single_output` writes one merged per-slide artifact (the
+    artifact per sampled class; `merged` writes one merged per-slide artifact (the
     union of tiles passing any class threshold).
   - `tiling.independent_sampling` chooses `independent_sampling` (tile each class separately)
     vs the default joint sampling (one pass over the union mask, then per-class coverage

--- a/hs2p/__init__.py
+++ b/hs2p/__init__.py
@@ -21,4 +21,4 @@ from hs2p.preprocessing import (
     preprocess_slide,
 )
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"

--- a/hs2p/configs/resolvers.py
+++ b/hs2p/configs/resolvers.py
@@ -65,13 +65,13 @@ def resolve_output_mode(cfg: Any) -> str:
     """Derive the coordinate output mode from ``tiling.masks.output_mode``.
 
     ``per_annotation`` (default) writes one coordinate artifact per sampled class;
-    ``single_output`` writes one merged per-slide artifact (the union of tiles passing any
+    ``merged`` writes one merged per-slide artifact (the union of tiles passing any
     class threshold).
     """
     masks_cfg = getattr(cfg.tiling, "masks", None)
     raw = getattr(masks_cfg, "output_mode", None) if masks_cfg is not None else None
     value = str(raw or CoordinateOutputMode.PER_ANNOTATION).lower()
-    valid = {CoordinateOutputMode.PER_ANNOTATION, CoordinateOutputMode.SINGLE_OUTPUT}
+    valid = {CoordinateOutputMode.PER_ANNOTATION, CoordinateOutputMode.MERGED}
     if value not in valid:
         raise ValueError(
             f"tiling.masks.output_mode must be one of {sorted(valid)}, got {value!r}"

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -186,7 +186,7 @@ def _compute_tiling_result(
                 CoordinateSelectionStrategy.MERGED_DEFAULT_TILING if has_mask else None
             ),
             output_mode=(
-                CoordinateOutputMode.SINGLE_OUTPUT if has_mask else None
+                CoordinateOutputMode.MERGED if has_mask else None
             ),
         )
 
@@ -231,7 +231,7 @@ def _compute_tiling_result(
                 CoordinateSelectionStrategy.MERGED_DEFAULT_TILING if has_mask else None
             ),
             output_mode=(
-                CoordinateOutputMode.SINGLE_OUTPUT if has_mask else None
+                CoordinateOutputMode.MERGED if has_mask else None
             ),
         )
         _write_mask_preview(
@@ -390,7 +390,7 @@ def tile_slide(
             else None
         ),
         output_mode=(
-            CoordinateOutputMode.SINGLE_OUTPUT
+            CoordinateOutputMode.MERGED
             if whole_slide.mask_path is not None
             else None
         ),
@@ -586,11 +586,11 @@ def _build_success_process_row(
     artifact: TilingArtifacts,
 ) -> dict[str, Any]:
     # A per-slide artifact with no annotation is binary tissue tiling, EXCEPT the merged
-    # SINGLE_OUTPUT annotation result (also annotation=None, but a union of annotation classes).
+    # MERGED annotation result (also annotation=None, but a union of annotation classes).
     # Record output_mode and label the merged row "merged" so it is not mistaken for tissue.
     if (
         artifact.annotation is None
-        and artifact.output_mode == CoordinateOutputMode.SINGLE_OUTPUT
+        and artifact.output_mode == CoordinateOutputMode.MERGED
     ):
         annotation_label = "merged"
     elif artifact.annotation is not None:
@@ -1199,7 +1199,7 @@ def tile_slides(
                         CoordinateSelectionStrategy.MERGED_DEFAULT_TILING if has_mask else None
                     ),
                     output_mode=(
-                        CoordinateOutputMode.SINGLE_OUTPUT if has_mask else None
+                        CoordinateOutputMode.MERGED if has_mask else None
                     ),
                 )
             compatibility = compatibility_specs[key]
@@ -1495,7 +1495,7 @@ def tile_slides(
         )
         if sampling_preview_enabled:
             # Annotation sampling renders one tiling preview per artifact (per label in
-            # PER_ANNOTATION, the single merged result in SINGLE_OUTPUT), each over its own
+            # PER_ANNOTATION, the single merged result in MERGED), each over its own
             # mask backdrop, through the shared preview executor. Each artifact gets its own
             # manifest row, finalized once its preview future completes.
             sampling_pixel_mapping = getattr(sampling, "pixel_mapping", None)

--- a/hs2p/tiling/single.py
+++ b/hs2p/tiling/single.py
@@ -437,7 +437,7 @@ def _build_joint_annotation_results(
 def _merge_annotation_results_to_single(
     results: "dict[str, TilingResult]",
 ) -> "TilingResult":
-    """Collapse a per-annotation result dict into one merged result for SINGLE_OUTPUT.
+    """Collapse a per-annotation result dict into one merged result for MERGED.
 
     The merged result is the **union** of every tile that passes *any* active
     annotation's coverage threshold (dedup'd over the shared candidate grid), with
@@ -449,7 +449,7 @@ def _merge_annotation_results_to_single(
     result_list = list(results.values())
     if not result_list:
         raise ValueError(
-            "SINGLE_OUTPUT merge requires at least one annotation result; got none "
+            "MERGED merge requires at least one annotation result; got none "
             "(no active annotations in the sampling spec?)"
         )
     template = result_list[0]
@@ -483,7 +483,7 @@ def _merge_annotation_results_to_single(
         template,
         tiles=merged_tiles,
         annotation=None,
-        output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+        output_mode=CoordinateOutputMode.MERGED,
     )
 
 
@@ -534,10 +534,10 @@ def build_per_annotation_tiling_results(
     # to per-annotation output and recording a bogus mode in metadata/process_list.
     if output_mode not in (
         CoordinateOutputMode.PER_ANNOTATION,
-        CoordinateOutputMode.SINGLE_OUTPUT,
+        CoordinateOutputMode.MERGED,
     ):
         raise ValueError(
-            f"output_mode must be PER_ANNOTATION or SINGLE_OUTPUT, got {output_mode!r}"
+            f"output_mode must be PER_ANNOTATION or MERGED, got {output_mode!r}"
         )
 
     _shared = dict(
@@ -585,7 +585,7 @@ def build_per_annotation_tiling_results(
             f"got {selection_strategy!r}"
         )
 
-    if output_mode == CoordinateOutputMode.SINGLE_OUTPUT:
+    if output_mode == CoordinateOutputMode.MERGED:
         # One merged result per slide (union of tiles passing any class threshold),
         # keyed by None so tile_slide/tile_slides persist a single per-slide artifact.
         return {None: _merge_annotation_results_to_single(results)}

--- a/hs2p/wsi/types.py
+++ b/hs2p/wsi/types.py
@@ -17,7 +17,7 @@ class CoordinateSelectionStrategy:
 
 
 class CoordinateOutputMode:
-    SINGLE_OUTPUT = "single_output"
+    MERGED = "merged"
     PER_ANNOTATION = "per_annotation"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hs2p"
-version = "4.1.0"
+version = "4.2.0"
 description = "Optimized slide tiling library for histopathology"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -119,7 +119,7 @@ no_implicit_reexport = true
 max-line-length = 160
 
 [tool.bumpver]
-current_version = "4.1.0"
+current_version = "4.2.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit = false       # We do version bumping in CI, not as a commit
 tag = false          # Git tag already exists — we don't auto-tag

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -418,10 +418,10 @@ def test_tile_slide_with_sampling_returns_per_annotation_dict(monkeypatch):
         CoordinateSelectionStrategy.INDEPENDENT_SAMPLING,
     ],
 )
-def test_single_output_merges_to_one_deduped_result_per_slide(
+def test_merged_merges_to_one_deduped_result_per_slide(
     patched_slide_and_mask_open, strategy
 ):
-    """SINGLE_OUTPUT collapses the per-annotation fan-out into one merged result keyed by
+    """MERGED collapses the per-annotation fan-out into one merged result keyed by
     None: the dedup'd union of every tile passing any class threshold (the dense-seg
     contract — each spatial tile once, multi-class mask attached downstream)."""
     common = dict(
@@ -440,14 +440,14 @@ def test_single_output_merges_to_one_deduped_result_per_slide(
         output_mode=CoordinateOutputMode.PER_ANNOTATION, **common
     )
     single = preprocess_slide_per_annotation(
-        output_mode=CoordinateOutputMode.SINGLE_OUTPUT, **common
+        output_mode=CoordinateOutputMode.MERGED, **common
     )
 
     # one entry, keyed None, annotation cleared, output_mode tagged
     assert set(single) == {None}
     merged = single[None]
     assert merged.annotation is None
-    assert merged.output_mode == CoordinateOutputMode.SINGLE_OUTPUT
+    assert merged.output_mode == CoordinateOutputMode.MERGED
 
     # merged coords == sorted unique union of the per-annotation coords
     expected = set()
@@ -547,8 +547,8 @@ def test_tile_slides_sampling_progress_counts_slides_not_artifacts(monkeypatch, 
     assert all(p["completed"] <= p["total"] for p in progress)
 
 
-def test_tile_slides_single_output_emits_one_artifact_per_slide(monkeypatch, tmp_path):
-    """With SINGLE_OUTPUT the sampling fan-out collapses: one artifact / process_list row
+def test_tile_slides_merged_emits_one_artifact_per_slide(monkeypatch, tmp_path):
+    """With MERGED the sampling fan-out collapses: one artifact / process_list row
     per slide (annotation None), which soma's per-slide extraction path consumes unchanged."""
     _patch_tile_slides_open(monkeypatch)
     artifacts = tile_slides(
@@ -559,7 +559,7 @@ def test_tile_slides_single_output_emits_one_artifact_per_slide(monkeypatch, tmp
         num_workers=1,
         sampling=_sampling_spec(),
         selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
-        output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+        output_mode=CoordinateOutputMode.MERGED,
     )
     assert len(artifacts) == 2  # one per slide, not per (slide, annotation)
     assert {a.sample_id for a in artifacts} == {"slide0", "slide1"}
@@ -572,7 +572,7 @@ def test_tile_slides_single_output_emits_one_artifact_per_slide(monkeypatch, tmp
     assert (rows["num_tiles"] > 0).all()
     # Merged single-output rows must be distinguishable from binary tissue tiling.
     assert set(rows["annotation"]) == {"merged"}
-    assert (rows["output_mode"] == CoordinateOutputMode.SINGLE_OUTPUT).all()
+    assert (rows["output_mode"] == CoordinateOutputMode.MERGED).all()
 
 
 @pytest.mark.parametrize("unsupported", ["resume", "read_coordinates_from", "save_tiles"])
@@ -625,7 +625,7 @@ def _patch_mask_preview_renderer(monkeypatch):
 
 @pytest.mark.parametrize(
     "output_mode",
-    [CoordinateOutputMode.PER_ANNOTATION, CoordinateOutputMode.SINGLE_OUTPUT],
+    [CoordinateOutputMode.PER_ANNOTATION, CoordinateOutputMode.MERGED],
 )
 def test_tile_slides_sampling_writes_one_mask_preview_per_slide(
     monkeypatch, tmp_path, output_mode
@@ -765,10 +765,10 @@ def test_tile_slides_per_annotation_writes_one_tiling_preview_per_label(
         CoordinateSelectionStrategy.INDEPENDENT_SAMPLING,
     ],
 )
-def test_tile_slides_single_output_writes_one_merged_tiling_preview(
+def test_tile_slides_merged_writes_one_merged_tiling_preview(
     monkeypatch, tmp_path, strategy
 ):
-    """SINGLE_OUTPUT: a single merged tiling preview at the flat preview location (no
+    """MERGED: a single merged tiling preview at the flat preview location (no
     per-annotation subdir), with its tiling_preview_path recorded on the merged row."""
     from hs2p.configs import PreviewConfig
 
@@ -784,7 +784,7 @@ def test_tile_slides_single_output_writes_one_merged_tiling_preview(
         num_workers=1,
         sampling=_sampling_spec_with_colors(),
         selection_strategy=strategy,
-        output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+        output_mode=CoordinateOutputMode.MERGED,
     )
     flat = tmp_path / "preview" / "tiling" / "slide0.jpg"
     assert flat.is_file()

--- a/tests/test_sampling_request_resolution.py
+++ b/tests/test_sampling_request_resolution.py
@@ -34,7 +34,7 @@ def test_annotation_config_triggers_sampling_without_tissue_threshold():
         {
             "tiling": {
                 "masks": {
-                    "output_mode": "single_output",
+                    "output_mode": "merged",
                     "pixel_mapping": {"grade_4": 4, "grade_5": 5},
                     "colors": {"grade_4": [255, 0, 0], "grade_5": [0, 0, 255]},
                     # null out the default tissue threshold → pure-grade sampling
@@ -51,7 +51,7 @@ def test_annotation_config_triggers_sampling_without_tissue_threshold():
     assert sampling is not None
     assert set(sampling.active_annotations) == {"grade_4", "grade_5"}
     assert strategy == CoordinateSelectionStrategy.JOINT_SAMPLING
-    assert output_mode == CoordinateOutputMode.SINGLE_OUTPUT
+    assert output_mode == CoordinateOutputMode.MERGED
 
 
 def test_independent_sampling_flag_selects_strategy():

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -337,7 +337,7 @@ def _patch_preprocess_slide(
                 CoordinateSelectionStrategy.MERGED_DEFAULT_TILING if has_mask else None
             ),
             "output_mode": (
-                CoordinateOutputMode.SINGLE_OUTPUT if has_mask else None
+                CoordinateOutputMode.MERGED if has_mask else None
             ),
             "sam2_checkpoint_path": (
                 segmentation.sam2_checkpoint_path if segmentation is not None else None
@@ -453,7 +453,7 @@ def test_tile_slide_passes_default_sampling_semantics_for_masked_slides(
             image_path="slide.svs",
             mask_path="slide-mask.png",
             selection_strategy=CoordinateSelectionStrategy.MERGED_DEFAULT_TILING,
-            output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+            output_mode=CoordinateOutputMode.MERGED,
         ),
         hook=captured.update,
     )
@@ -473,7 +473,7 @@ def test_tile_slide_passes_default_sampling_semantics_for_masked_slides(
         captured["selection_strategy"]
         == CoordinateSelectionStrategy.MERGED_DEFAULT_TILING
     )
-    assert captured["output_mode"] == CoordinateOutputMode.SINGLE_OUTPUT
+    assert captured["output_mode"] == CoordinateOutputMode.MERGED
     assert captured["tissue_mask_path"] == Path("slide-mask.png")
 
 
@@ -489,7 +489,7 @@ def test_tile_slide_allows_masked_slides_without_segmentation_config(
             image_path="slide.svs",
             mask_path="slide-mask.png",
             selection_strategy=CoordinateSelectionStrategy.MERGED_DEFAULT_TILING,
-            output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+            output_mode=CoordinateOutputMode.MERGED,
         ),
         hook=captured.update,
     )
@@ -518,7 +518,7 @@ def test_tile_slide_returns_named_arrays(
             image_path="slide-1.svs",
             mask_path="slide-1-mask.png",
             selection_strategy=CoordinateSelectionStrategy.MERGED_DEFAULT_TILING,
-            output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+            output_mode=CoordinateOutputMode.MERGED,
         ),
     )
 
@@ -569,7 +569,7 @@ def test_compute_tiling_result_uses_preprocessing_core(
             image_path="slide-1.svs",
             mask_path="slide-1-mask.png",
             selection_strategy=CoordinateSelectionStrategy.MERGED_DEFAULT_TILING,
-            output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+            output_mode=CoordinateOutputMode.MERGED,
         ),
         hook=captured.update,
     )
@@ -607,7 +607,7 @@ def test_compute_tiling_result_uses_preprocessing_core(
         captured["selection_strategy"]
         == CoordinateSelectionStrategy.MERGED_DEFAULT_TILING
     )
-    assert captured["output_mode"] == CoordinateOutputMode.SINGLE_OUTPUT
+    assert captured["output_mode"] == CoordinateOutputMode.MERGED
 
     assert result.sample_id == "slide-1"
     assert result.image_path == Path("slide-1.svs")
@@ -615,7 +615,7 @@ def test_compute_tiling_result_uses_preprocessing_core(
     assert result.backend == "asap"
     assert len(result.x) == 2
     assert result.selection_strategy == CoordinateSelectionStrategy.MERGED_DEFAULT_TILING
-    assert result.output_mode == CoordinateOutputMode.SINGLE_OUTPUT
+    assert result.output_mode == CoordinateOutputMode.MERGED
     np.testing.assert_array_equal(
         _coords_array(result), np.array([[100, 200], [300, 400]], dtype=np.int64)
     )

--- a/tests/test_tiling_preview_mask_overlay.py
+++ b/tests/test_tiling_preview_mask_overlay.py
@@ -123,7 +123,7 @@ def _sampling_spec() -> SamplingSpec:
     "output_mode, selection_strategy",
     [
         (CoordinateOutputMode.PER_ANNOTATION, CoordinateSelectionStrategy.INDEPENDENT_SAMPLING),
-        (CoordinateOutputMode.SINGLE_OUTPUT, CoordinateSelectionStrategy.JOINT_SAMPLING),
+        (CoordinateOutputMode.MERGED, CoordinateSelectionStrategy.JOINT_SAMPLING),
     ],
 )
 def test_annotation_tiling_preview_renders_on_real_slide(

--- a/tests/test_unified_process_list_schema.py
+++ b/tests/test_unified_process_list_schema.py
@@ -44,9 +44,9 @@ def test_success_row_annotation_preserved_when_set():
     assert row["annotation"] == "tumor"
 
 
-def test_single_output_row_labeled_merged_not_tissue():
-    """A merged SINGLE_OUTPUT artifact has annotation=None like binary tissue, but must not be
-    recorded as 'tissue' — it carries output_mode=single_output and the label 'merged'."""
+def test_merged_row_labeled_merged_not_tissue():
+    """A merged MERGED artifact has annotation=None like binary tissue, but must not be
+    recorded as 'tissue' — it carries output_mode=merged and the label 'merged'."""
     from hs2p.wsi.types import CoordinateOutputMode
 
     artifact = TilingArtifacts(
@@ -55,13 +55,13 @@ def test_single_output_row_labeled_merged_not_tissue():
         coordinates_meta_path=Path("tiles/slide-1.coordinates.meta.json"),
         num_tiles=5,
         annotation=None,
-        output_mode=CoordinateOutputMode.SINGLE_OUTPUT,
+        output_mode=CoordinateOutputMode.MERGED,
     )
     row = orchestration_mod._build_success_process_row(
         whole_slide=_whole_slide(), artifact=artifact
     )
     assert row["annotation"] == "merged"
-    assert row["output_mode"] == CoordinateOutputMode.SINGLE_OUTPUT
+    assert row["output_mode"] == CoordinateOutputMode.MERGED
 
 
 def test_binary_tissue_row_has_no_output_mode():


### PR DESCRIPTION
## What

Rename the coordinate output-mode value `single_output` → `merged`, and the constant `CoordinateOutputMode.SINGLE_OUTPUT` → `CoordinateOutputMode.MERGED`, across code, tests, and docs. Bumps version `4.1.0` → `4.2.0`.

## Why

`single_output` was the odd one out: hs2p's internals already speak "merged" (`merged_coords`, `_merge_*`, and the `merged` process-list row label). Aligning the public name with that vocabulary reads more clearly.

## Breaking change

`CoordinateOutputMode.SINGLE_OUTPUT` and the config value `tiling.masks.output_mode: single_output` are removed with **no backward-compat alias**.

**Migration:** use `CoordinateOutputMode.MERGED` / `output_mode: merged`.

A merged artifact now carries `output_mode="merged"` and the process-list label `annotation="merged"` — the two intentionally coincide ("merged-mode row, labeled merged").

## Verification

- All sampling / output-mode tests pass (110/110).
- Full suite: 318 passed. The only failures (20, in `tests/test_standalone_mask_pyramid.py`) are pre-existing and unrelated — a missing `scripts/generate_tissue_mask_pyramid.py` in the environment; that file is byte-identical to `main`.

## Downstream

Unblocks slide2vec's annotation-aware feature extraction (slide2vec issue #154 targets the 4.2.0 release and uses `output_mode: merged`).