### PR TITLE
Flatten the 'merged' annotation label to the output root

### DIFF
--- a/hs2p/fileops.py
+++ b/hs2p/fileops.py
@@ -10,12 +10,17 @@ def is_flattened_annotation(annotation: str | None) -> bool:
 
     This is the single source of truth for the annotation→path rule shared by the
     coordinate/tar artifact code and the preview/visualization layer: ``None`` and the
-    sentinel ``"tissue"`` label collapse to the flat layout (no per-annotation subdir),
-    while every other label gets its own ``.../{annotation}/...`` location. It lives in
-    this leaf module (stdlib-only deps) so both layers can import it without a circular
-    import and a preview file can never land in a different place than its coordinate set.
+    sentinel labels ``"tissue"`` and ``"merged"`` collapse to the flat layout (no
+    per-annotation subdir), while every other label gets its own ``.../{annotation}/...``
+    location. ``"merged"`` is the union-of-classes output mode: it carries no single class
+    and so belongs at the flat root alongside plain tissue. Flattening it here lets the
+    informative ``"merged"`` process-list label flow through to consumers without forcing
+    them to blank it to ``None`` to keep the artifact at the flat root (which would also
+    erase the tissue-vs-merged distinction). It lives in this leaf module (stdlib-only
+    deps) so both layers can import it without a circular import and a preview file can
+    never land in a different place than its coordinate set.
     """
-    return annotation is None or annotation == "tissue"
+    return annotation is None or annotation in ("tissue", "merged")
 
 
 def promote_temp_file(temp_path: Path, target_path: Path) -> None:

--- a/tests/test_annotation_path_flattening.py
+++ b/tests/test_annotation_path_flattening.py
@@ -1,4 +1,4 @@
-"""The annotation→path flattening rule (None/tissue → flat root, other labels → a
+"""The annotation→path flattening rule (None/tissue/merged → flat root, other labels → a
 per-annotation subdir) must live in a single shared helper that both the artifact code
 and the preview/visualization layer can import without a circular import."""
 
@@ -7,12 +7,14 @@ import pytest
 from hs2p.fileops import is_flattened_annotation
 
 
-@pytest.mark.parametrize("annotation", [None, "tissue"])
-def test_flattened_for_none_and_tissue(annotation):
+@pytest.mark.parametrize("annotation", [None, "tissue", "merged"])
+def test_flattened_for_none_tissue_and_merged(annotation):
+    # "merged" is the union-of-classes output mode: it carries no single class label, so
+    # its artifacts belong at the flat root alongside plain tissue (not a `merged/` subdir).
     assert is_flattened_annotation(annotation) is True
 
 
-@pytest.mark.parametrize("annotation", ["grade_4", "tumor", "Tissue", "tissue_x"])
+@pytest.mark.parametrize("annotation", ["grade_4", "tumor", "Tissue", "tissue_x", "Merged", "merged_x"])
 def test_not_flattened_for_named_labels(annotation):
     assert is_flattened_annotation(annotation) is False
 


### PR DESCRIPTION
## What

Make `is_flattened_annotation` treat `"merged"` as flat (alongside `None` and `"tissue"`), so the union-of-classes output mode lands at the flat output root rather than a stray `merged/` subdirectory.

```python
return annotation is None or annotation in ("tissue", "merged")
```

## Why

`is_flattened_annotation` is the single source of truth for the annotation→path rule. Merged artifacts are already written to the flat root internally — a merged `TilingResult` carries `annotation=None` — but the process_list row is labelled `"merged"` (by `_build_success_process_row`) so it isn't mistaken for plain tissue.

That left consumers in a bind: to honor the flat layout they had to blank `"merged"` → `None` before feeding it to the path rule, which **also erased the tissue-vs-merged distinction** in the label they surface to users. Flattening `"merged"` here lets the informative label flow through unchanged while still resolving to the flat root.

## Safety

The change is **inert within hs2p**: no call site ever passes the literal `"merged"` into the rule — merged results carry `annotation=None`, and `is_flattened_annotation` is only ever called with a `TilingResult.annotation` (`None` / `"tissue"` / a real class). So no hs2p artifact path moves. It only unblocks downstream consumers (e.g. slide2vec) that read the `"merged"` process_list label.

## Tests

- `test_annotation_path_flattening` now asserts `"merged"` flattens, and that look-alikes (`"Merged"`, `"merged_x"`) still get their own subdir.
- Full suite green (the only failures are the pre-existing `test_standalone_mask_pyramid.py` ones, which import a `scripts/generate_tissue_mask_pyramid.py` that is absent from the tree — unrelated to this change).