### PR TITLE
Fail fast on oversized non-pyramidal mask reads

### DIFF
--- a/hs2p/tiling/mask.py
+++ b/hs2p/tiling/mask.py
@@ -15,6 +15,13 @@ from hs2p.wsi.reader import open_slide, select_level, select_level_for_downsampl
 DEFAULT_SAM2_THUMBNAIL_SPACING_UM = 8.0
 DEFAULT_SAM2_THUMBNAIL_TOLERANCE = 0.05
 
+# Reading a mask level larger than this many pixels means the mask lacks a pyramid level
+# near the requested segmentation spacing (the read would be downsized to the seg grid
+# immediately afterward). Reading + np.unique(int64) on such a raster OOMs the process, so
+# fail fast with an actionable message instead. 256 Mpx ≈ 256 MB uint8 (+ ~2 GB transient
+# int64 unique) — safe, and ~52x above the largest healthy BEETLE mask read (4.9 Mpx).
+MAX_MASK_READ_PX = 256_000_000
+
 
 def _reduce_mask_channels(mask: np.ndarray) -> np.ndarray:
     if mask.ndim == 3:
@@ -86,6 +93,15 @@ def _read_discrete_mask_level(
     for tissue masks, or a class-value-subset check for multi-class annotation masks.
     """
     mask_size = mask_slide.level_dimensions[mask_level]
+    mw, mh = int(mask_size[0]), int(mask_size[1])
+    if mw * mh > MAX_MASK_READ_PX:
+        raise ValueError(
+            f"{label} {mask_path}: nearest level to the requested segmentation spacing is "
+            f"level {mask_level} at {mw}x{mh} ({mw * mh / 1e6:.0f} Mpx), exceeding "
+            f"MAX_MASK_READ_PX ({MAX_MASK_READ_PX / 1e6:.0f} Mpx). The mask likely lacks a "
+            f"pyramid level near that spacing — regenerate it as a multi-resolution pyramidal "
+            f"TIFF, or lower seg_downsample."
+        )
     backend_mask = _reduce_mask_channels(mask_slide.read_region((0, 0), mask_level, mask_size))
     if is_discrete(backend_mask):
         return _as_discrete_label_array(backend_mask)

--- a/tests/test_mask_read_size_guard.py
+++ b/tests/test_mask_read_size_guard.py
@@ -1,0 +1,224 @@
+"""Fail-fast guard for oversized (non-pyramidal) mask reads.
+
+A mask whose nearest pyramid level to the requested segmentation spacing is still huge
+(because the mask lacks a coarse pyramid level) would force ``read_region`` to materialise a
+multi-GB raster, immediately followed by an 8x ``np.unique(int64)`` copy, OOM-killing the job.
+``_read_discrete_mask_level`` is the single chokepoint both read paths funnel through, so a
+size guard there protects the precomputed-tissue path (``_read_mask_level``) and the annotation
+path (``_read_label_mask_at_seg``) at once. These tests assert the guard fires *before* any
+read, and that normal under-cap masks still read/validate unchanged through both paths.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import hs2p.tiling.mask as tiling_mask_mod
+from hs2p.tiling.mask import (
+    MAX_MASK_READ_PX,
+    _read_discrete_mask_level,
+    _read_mask_level,
+    load_annotation_label_mask,
+    load_precomputed_tissue_mask,
+)
+
+
+class _ExplodingMaskSlide:
+    """A single-level mask whose only level exceeds the read cap; reading it must never
+    happen, so ``read_region`` fails loudly if the guard lets execution reach it."""
+
+    def __init__(self, level_dimensions):
+        self.level_dimensions = level_dimensions
+        self.level_downsamples = [1.0]
+        self.spacing = 0.25
+
+    def read_region(self, *args, **kwargs):  # pragma: no cover - must not be called
+        raise AssertionError(
+            "read_region was called despite the oversized-mask guard — the guard must "
+            "fail fast before any large allocation"
+        )
+
+    def close(self):
+        pass
+
+
+class _FakeMaskSlide:
+    """A normal small mask that reads a discrete single-value raster at its only level."""
+
+    def __init__(self, level_dimensions, *, spacing=0.25, value=0):
+        self.level_dimensions = level_dimensions
+        self.level_downsamples = [1.0]
+        self.spacing = spacing
+        self._value = int(value)
+
+    def read_region(self, location, level, size):
+        del location, level
+        width, height = int(size[0]), int(size[1])
+        return np.full((height, width), self._value, dtype=np.uint8)
+
+    def close(self):
+        pass
+
+
+def _make_wsi_slide(*, backend_name="asap"):
+    return SimpleNamespace(
+        level_downsamples=[1.0, 4.0],
+        spacing=0.25,
+        level_dimensions=[(100, 100), (25, 25)],
+        dimensions=(100, 100),
+        backend_name=backend_name,
+    )
+
+
+# Dimensions of the real BEETLE mask that triggered the SIGKILL (2740 Mpx, well over the cap).
+_OVERSIZED_DIMS = (62407, 43898)
+
+
+def _assert_oversized_message(message: str, *, label: str, mask_path: str) -> None:
+    assert label in message
+    assert mask_path in message
+    assert "level 0" in message
+    assert f"{_OVERSIZED_DIMS[0]}x{_OVERSIZED_DIMS[1]}" in message
+    assert "Mpx" in message
+    assert "MAX_MASK_READ_PX" in message
+    assert "pyramid" in message
+    assert "seg_downsample" in message
+
+
+# --- guard fires before any read ------------------------------------------------------
+
+
+@pytest.mark.parametrize("label", ["Annotation mask", "Precomputed tissue mask"])
+def test_read_discrete_mask_level_guard_fires_before_read(label):
+    mask_path = "/data/masks/oversized.tif"
+    mask_slide = _ExplodingMaskSlide(level_dimensions=[_OVERSIZED_DIMS])
+
+    with pytest.raises(ValueError) as excinfo:
+        _read_discrete_mask_level(
+            mask_path=mask_path,
+            mask_slide=mask_slide,
+            mask_level=0,
+            is_discrete=lambda mask: True,
+            label=label,
+        )
+
+    _assert_oversized_message(str(excinfo.value), label=label, mask_path=mask_path)
+
+
+def test_precomputed_tissue_path_routes_through_guard(monkeypatch):
+    mask_path = "/data/masks/oversized-tissue.tif"
+    mask_slide = _ExplodingMaskSlide(level_dimensions=[_OVERSIZED_DIMS])
+    monkeypatch.setattr(
+        tiling_mask_mod, "open_slide", lambda *a, **k: mask_slide
+    )
+    slide = _make_wsi_slide()
+
+    with pytest.raises(ValueError) as excinfo:
+        load_precomputed_tissue_mask(
+            mask_path=mask_path,
+            slide=slide,
+            seg_level=1,
+            tissue_value=1,
+        )
+
+    _assert_oversized_message(
+        str(excinfo.value), label="Precomputed tissue mask", mask_path=mask_path
+    )
+
+
+def test_annotation_path_routes_through_guard(monkeypatch):
+    mask_path = "/data/masks/oversized-annotation.tif"
+    mask_slide = _ExplodingMaskSlide(level_dimensions=[_OVERSIZED_DIMS])
+    monkeypatch.setattr(
+        tiling_mask_mod, "open_slide", lambda *a, **k: mask_slide
+    )
+    # backend_name="openslide" disables the degenerate-read openslide retry in
+    # load_annotation_label_mask so the guard's ValueError surfaces directly.
+    slide = _make_wsi_slide(backend_name="openslide")
+
+    with pytest.raises(ValueError) as excinfo:
+        load_annotation_label_mask(
+            mask_path=mask_path,
+            slide=slide,
+            seg_level=1,
+            valid_values={0, 1},
+        )
+
+    _assert_oversized_message(
+        str(excinfo.value), label="Annotation mask", mask_path=mask_path
+    )
+
+
+# --- under-cap masks still read/validate unchanged ------------------------------------
+
+
+def test_read_discrete_mask_level_passthrough_under_cap():
+    mask_slide = _FakeMaskSlide(level_dimensions=[(25, 25)], value=0)
+    result = _read_discrete_mask_level(
+        mask_path="/data/masks/small.tif",
+        mask_slide=mask_slide,
+        mask_level=0,
+        is_discrete=lambda mask: True,
+        label="Precomputed tissue mask",
+    )
+    assert result.shape == (25, 25)
+    assert result.dtype == np.uint8
+
+
+def test_read_mask_level_passthrough_under_cap():
+    mask_slide = _FakeMaskSlide(level_dimensions=[(25, 25)], value=1)
+    result = _read_mask_level(
+        mask_path="/data/masks/small.tif",
+        mask_slide=mask_slide,
+        mask_level=0,
+        tissue_value=1,
+    )
+    assert result.shape == (25, 25)
+    assert int(result.max()) == 1
+
+
+def test_precomputed_tissue_path_passthrough_under_cap(monkeypatch):
+    mask_slide = _FakeMaskSlide(level_dimensions=[(25, 25)], value=1)
+    monkeypatch.setattr(
+        tiling_mask_mod, "open_slide", lambda *a, **k: mask_slide
+    )
+    slide = _make_wsi_slide()
+
+    mask, mask_level, mask_spacing_um = load_precomputed_tissue_mask(
+        mask_path="/data/masks/small.tif",
+        slide=slide,
+        seg_level=1,
+        tissue_value=1,
+    )
+
+    assert mask.shape == (25, 25)
+    assert mask_level == 0
+    assert set(np.unique(mask).tolist()) <= {0, 255}
+    assert int(mask.max()) == 255
+
+
+def test_annotation_path_passthrough_under_cap(monkeypatch):
+    mask_slide = _FakeMaskSlide(level_dimensions=[(25, 25)], value=0)
+    monkeypatch.setattr(
+        tiling_mask_mod, "open_slide", lambda *a, **k: mask_slide
+    )
+    slide = _make_wsi_slide(backend_name="openslide")
+
+    mask, mask_level, mask_spacing_um = load_annotation_label_mask(
+        mask_path="/data/masks/small.tif",
+        slide=slide,
+        seg_level=1,
+        valid_values={0, 1},
+    )
+
+    assert mask.shape == (25, 25)
+    assert mask_level == 0
+    assert mask.dtype == np.uint8
+
+
+def test_max_mask_read_px_threshold_value():
+    # Locks the agreed cap (256 Mpx) — sits in the empirical gap between healthy BEETLE
+    # mask reads (<= 4.9 Mpx) and the fatal 2740 Mpx mask.
+    assert MAX_MASK_READ_PX == 256_000_000


### PR DESCRIPTION
## Problem

A mask whose nearest pyramid level to the requested segmentation spacing is still huge — because the mask lacks a coarse pyramid level — forces `read_region` to materialise a multi-GB raster, immediately followed by an 8× `np.unique(int64)` copy. On a real slide this OOM-killed the job.

This was the root cause of a BEETLE dense-extraction SIGKILL: one single-level (non-pyramidal) annotation mask resolved to level 0 and was read at full resolution **62407×43898 = 2740 Mpx**, blowing up to ~48 GB live (2.7 GB uint8 read + 21.9 GB int64 `np.unique` + an 8 GB RGB read canvas) and exceeding the cgroup limit. Every other mask in the cohort has a pyramid and resolves to a ~5 Mpx level — only this one degenerates.

## Fix

Add a size-gated guard in `_read_discrete_mask_level` — the single chokepoint both the precomputed-tissue path (`_read_mask_level`) and the annotation path (`_read_label_mask_at_seg`) funnel through. When the level about to be read exceeds `MAX_MASK_READ_PX` (256 Mpx), it raises an actionable `ValueError` **before** any `read_region`, naming the mask, the level, its dimensions/Mpx, the cap, and the remedy (regenerate as a multi-resolution pyramidal TIFF, or lower `seg_downsample`).

### Threshold

`MAX_MASK_READ_PX = 256_000_000`. Measured across all 584 masks in the affected cohort: healthy masks read ≤ 4.9 Mpx (median 0.92), and nothing lands between 8 and 2000 Mpx — the one fatal mask reads 2740 Mpx. 256 Mpx sits cleanly in that gap: ~52× headroom over the largest healthy read (so a mask that's merely a pyramid step or two coarse still passes) and ~11× below the fatal one. Worst-case transient at the cap is ~256 MB uint8 + ~2 GB int64 — safe.

## Tests

New `tests/test_mask_read_size_guard.py` (9 tests):
- Guard fires **before** any read on both the annotation and precomputed-tissue paths (a fake slide whose `read_region` asserts if invoked proves it's pre-allocation), with the informative message asserted.
- Under-cap masks read/validate unchanged through both paths.
- Threshold value locked.

Full suite: 309 passed, 1 skipped (two pre-existing collection errors from a missing OpenSlide binary in the venv are unrelated to this change).