### PR TITLE
Document agent triage labels

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Agent triage labels
+
+The issue-shipping workflow uses these repository labels without aliases:
+
+| Workflow state | Repository label |
+| --- | --- |
+| Eligible for implementation | `ready-for-agent` |
+| Implementation in progress | `agent:in-progress` |
+| Pull request in review | `agent:in-review` |
+| Gate failed; changes required | `agent:needs-changes` |
+


### PR DESCRIPTION
Records the canonical-to-repository label mapping required by the resumable issue-shipping workflow.\n\nThis is a preflight-only documentation change; it does not modify runtime behavior.