### PR TITLE
Reserve merged output identity and enforce annotation label range

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -5,7 +5,10 @@
 ## Artifact locations
 
 - Tiling writes one artifact pair per slide under `tiles/`
-- Sampling writes one artifact pair per annotation under `tiles/<annotation>/`
+- Per-annotation sampling writes one artifact pair under `tiles/<annotation>/`.
+  The conventional `tissue` annotation stays flat under `tiles/`.
+- Structural merged sampling writes one flat artifact pair under `tiles/`; `merged` is
+  reserved as an output identity and cannot be used as an annotation name.
 
 Each successful output produces:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -133,10 +133,13 @@ backend fields/columns) are rejected clearly rather than loaded.
   - annotation sampling activates when `pixel_mapping` declares a foreground class other than
     the default `tissue`; otherwise the CLI runs binary tissue tiling. Each slide's annotation
     mask is taken from the `mask_path` column of the input CSV.
-  - `pixel_mapping` is your own label vocabulary: it must enumerate **every** label value present in the raster
-    (each value distinct, in `[0, 65535]`); any pixel value not declared here makes the mask
-    read fail (the discreteness guard). If the raster reserves a value for unannotated
-    pixels, declare it like any other class and simply give it no `min_coverage` threshold.
+  - `pixel_mapping` is your own label vocabulary: it must enumerate **every** label value
+    present in the raster (each value distinct, in `[0, 255]`, regardless of the raster's
+    integer storage width). The annotation name `merged` is reserved for structural merged
+    coordinate output; `tissue` remains a valid conventional annotation. Any pixel value not
+    declared here makes the mask read fail (the discreteness guard). If the raster reserves a
+    value for unannotated pixels, declare it like any other class and simply give it no
+    `min_coverage` threshold.
   - `min_coverage` selects **which** classes are actually sampled: only classes given a
     (non-null) coverage threshold get tiled, and the coverage report's `frac`/`est_tiles`
     are computed relative to those classes. To sample a subset (e.g. only Gleason grades 4
@@ -146,8 +149,9 @@ backend fields/columns) are rejected clearly rather than loaded.
     tissue class from sampling, and set `pixel_mapping.tissue: null` to remove the default
     label entirely (required to reuse its value, e.g. a `tumor: 1` mask).
   - `output_mode` (annotation sampling only): `per_annotation` (default) writes one coordinate
-    artifact per sampled class; `merged` writes one merged per-slide artifact (the
-    union of tiles passing any class threshold).
+    artifact per sampled class; `merged` writes one flat merged per-slide artifact (the
+    union of tiles passing any class threshold), identified structurally rather than as an
+    annotation named `merged`.
   - `tiling.independent_sampling` chooses `independent_sampling` (tile each class separately)
     vs the default joint sampling (one pass over the union mask, then per-class coverage
     filtering).

--- a/hs2p/artifacts.py
+++ b/hs2p/artifacts.py
@@ -14,7 +14,11 @@ from hs2p.preprocessing import (
     _load_tiling_result_from_paths,
     _save_tiling_result,
 )
-from hs2p.fileops import is_flattened_annotation, promote_temp_file
+from hs2p.fileops import (
+    is_flattened_annotation,
+    promote_temp_file,
+    validate_annotation_name,
+)
 
 
 @dataclass(frozen=True)
@@ -95,32 +99,14 @@ def validate_result_consistency(result: TilingResult) -> None:
         raise ValueError("tile_index must be a contiguous range from 0 to num_tiles-1")
 
 
-def _ensure_safe_path_component(name: str) -> str:
-    """Reject annotation labels that aren't a single, contained path component.
-
-    Annotation names become directories under ``output_dir/tiles``; a value like ``../outside``
-    or ``/tmp/owned`` would escape the run's output tree. This is enforced at the filesystem
-    boundary so it holds for every caller — the CLI resolver and the public ``tile_slides``
-    API, which accepts a ``SamplingSpec`` directly and never passes through config validation.
-    """
-    if (
-        not name
-        or name in {".", ".."}
-        or any(ch in name for ch in ("/", "\\", "\x00"))
-    ):
-        raise ValueError(
-            f"annotation label {name!r} must be a safe path component "
-            "(non-empty, no '/'\\ separators, not '.' or '..')"
-        )
-    return name
-
-
 def _annotation_tiles_dir(output_dir: Path, annotation: str | None) -> Path:
     """Return the tiles sub-directory, collapsing 'tissue' to the flat layout."""
     base = Path(output_dir) / "tiles"
     if is_flattened_annotation(annotation):
         return base
-    return base / _ensure_safe_path_component(annotation)
+    assert annotation is not None
+    validate_annotation_name(annotation)
+    return base / annotation
 
 
 def save_tiling_result(
@@ -130,6 +116,8 @@ def save_tiling_result(
     annotation: str | None = None,
     tiles_dir: Path | None = None,
 ) -> "TilingArtifacts":
+    validate_annotation_name(annotation)
+    validate_annotation_name(result.annotation)
     validate_result_consistency(result)
     tiles_dir = (
         Path(tiles_dir)

--- a/hs2p/configs/resolvers.py
+++ b/hs2p/configs/resolvers.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 
+from hs2p.fileops import validate_annotation_name
 from hs2p.wsi.types import CoordinateOutputMode, CoordinateSelectionStrategy, SamplingSpec
 
 from .models import FilterConfig, PreviewConfig, SegmentationConfig, TilingConfig
@@ -107,7 +108,8 @@ def resolve_sampling_request(
     the binary tissue-tiling path. The signal is configuration, not label names: a spec equal
     to :func:`build_default_sampling_spec` (the untouched default ``{background, tissue}``
     setup) is binary tissue tiling; any change to the label vocabulary or the sampled set opts
-    into multi-label annotation sampling. No label name is reserved at this boundary.
+    into multi-label annotation sampling. The structural output identity ``"merged"`` is
+    reserved and rejected while resolving the sampling spec.
     """
     spec = resolve_sampling_spec(cfg, tiling=tiling)
     if not spec.active_annotations:
@@ -166,10 +168,9 @@ def _merge_sampling_mapping(
 def validate_pixel_mapping(pixel_mapping: dict[str, int]) -> None:
     """Validate the annotation ``pixel_mapping`` up front, before any slide is opened.
 
-    ``pixel_mapping`` is the user's own label vocabulary — no name is reserved. Each label
-    must map to a distinct, non-negative integer within the supported ``uint16`` range so the
-    read path can split classes by exact value without collisions or silent wrapping (see
-    :func:`hs2p.tiling.mask._as_discrete_label_array`).
+    ``pixel_mapping`` is the user's own label vocabulary except for ``"merged"``, which names
+    structural merged coordinate output. Each label must map to a distinct integer in the
+    preview-safe range ``[0, 255]`` so all consumers preserve it without silent wrapping.
 
     Label *names* become on-disk path components (``output_dir/tiles/<label>/...`` for
     per-annotation artifacts), so they must be safe single path components — no separators,
@@ -177,24 +178,16 @@ def validate_pixel_mapping(pixel_mapping: dict[str, int]) -> None:
     """
     seen: dict[int, str] = {}
     for annotation, value in pixel_mapping.items():
-        if (
-            not annotation
-            or annotation in {".", ".."}
-            or any(ch in annotation for ch in ("/", "\\", "\x00"))
-        ):
-            raise ValueError(
-                f"pixel_mapping label {annotation!r} must be a safe path component "
-                "(non-empty, no '/'\\ separators, not '.' or '..')"
-            )
+        validate_annotation_name(annotation)
         if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
             raise ValueError(
                 f"pixel_mapping['{annotation}'] must be an integer label value, got {value!r}"
             )
         ivalue = int(value)
-        if ivalue < 0 or ivalue > 65535:
+        if ivalue < 0 or ivalue > 255:
             raise ValueError(
                 f"pixel_mapping['{annotation}']={ivalue} is outside the supported "
-                "label range [0, 65535]"
+                "label range [0, 255]"
             )
         if ivalue in seen:
             raise ValueError(
@@ -202,6 +195,24 @@ def validate_pixel_mapping(pixel_mapping: dict[str, int]) -> None:
                 f"'{annotation}' and '{seen[ivalue]}' both map to {ivalue}"
             )
         seen[ivalue] = annotation
+
+
+def validate_sampling_spec(sampling: SamplingSpec) -> None:
+    """Validate every annotation declaration accepted by direct Python sampling APIs."""
+    validate_pixel_mapping(sampling.pixel_mapping)
+    _validate_annotation_names(
+        sampling.active_annotations,
+        sampling.tissue_percentage,
+        sampling.color_mapping,
+    )
+
+
+def _validate_annotation_names(*declarations: Any) -> None:
+    for declaration in declarations:
+        if declaration is None:
+            continue
+        for annotation in declaration:
+            validate_annotation_name(annotation)
 
 
 def validate_color_mapping(
@@ -297,6 +308,7 @@ def _resolve_sampling_spec_from_masks(masks_cfg: Any, *, tiling: TilingConfig) -
         getattr(masks_cfg, "colors", None),
         field_name="colors",
     )
+    _validate_annotation_names(pixel_mapping, min_coverage, colors)
     pixel_mapping, (min_coverage, colors) = _drop_null_labels(
         pixel_mapping, min_coverage, colors
     )
@@ -345,6 +357,7 @@ def _resolve_sampling_spec_from_sampling_params(
         getattr(sampling_config, "color_mapping", None),
         field_name="color_mapping",
     )
+    _validate_annotation_names(pixel_mapping, tissue_percentage, color_mapping)
     pixel_mapping, (tissue_percentage, color_mapping) = _drop_null_labels(
         pixel_mapping, tissue_percentage, color_mapping
     )

--- a/hs2p/fileops.py
+++ b/hs2p/fileops.py
@@ -5,22 +5,37 @@ import shutil
 from pathlib import Path
 
 
+def validate_annotation_name(annotation: str | None) -> str | None:
+    """Validate an annotation name, accepting ``None`` for structural output."""
+    if annotation is None:
+        return None
+    if annotation == "merged":
+        raise ValueError(
+            "annotation name 'merged' is reserved for structural merged coordinate output"
+        )
+    if (
+        not annotation
+        or annotation in {".", ".."}
+        or any(ch in annotation for ch in ("/", "\\", "\x00"))
+    ):
+        raise ValueError(
+            f"annotation label {annotation!r} must be a safe path component "
+            "(non-empty, no '/'\\ separators, not '.' or '..')"
+        )
+    return annotation
+
+
 def is_flattened_annotation(annotation: str | None) -> bool:
     """Decide whether an annotation's artifacts land at the flat output root.
 
     This is the single source of truth for the annotation→path rule shared by the
     coordinate/tar artifact code and the preview/visualization layer: ``None`` and the
-    sentinel labels ``"tissue"`` and ``"merged"`` collapse to the flat layout (no
-    per-annotation subdir), while every other label gets its own ``.../{annotation}/...``
-    location. ``"merged"`` is the union-of-classes output mode: it carries no single class
-    and so belongs at the flat root alongside plain tissue. Flattening it here lets the
-    informative ``"merged"`` process-list label flow through to consumers without forcing
-    them to blank it to ``None`` to keep the artifact at the flat root (which would also
-    erase the tissue-vs-merged distinction). It lives in this leaf module (stdlib-only
-    deps) so both layers can import it without a circular import and a preview file can
-    never land in a different place than its coordinate set.
+    conventional ``"tissue"`` label collapse to the flat layout (no per-annotation subdir),
+    while every other label gets its own ``.../{annotation}/...`` location. Structural merged
+    output is represented by ``annotation=None`` with ``output_mode="merged"``; the literal
+    annotation name ``"merged"`` is reserved and must be rejected at caller boundaries.
     """
-    return annotation is None or annotation in ("tissue", "merged")
+    return annotation is None or annotation == "tissue"
 
 
 def promote_temp_file(temp_path: Path, target_path: Path) -> None:

--- a/hs2p/tiling/mask.py
+++ b/hs2p/tiling/mask.py
@@ -8,6 +8,7 @@ import cv2
 import numpy as np
 
 from hs2p.configs import SegmentationConfig
+from hs2p.configs.resolvers import validate_pixel_mapping
 from hs2p.segmentation import segment_tissue_image
 from hs2p.tiling.contours import _normalize_level_downsamples
 from hs2p.tiling.result import ResolvedAnnotationMasks, ResolvedTissueMask, Sam2Thumbnail
@@ -481,9 +482,11 @@ def resolve_annotation_masks(
     was missing from the codebase — the annotation counterpart of
     :func:`resolve_tissue_mask`'s precomputed path. ``pixel_mapping`` maps class name to the
     integer pixel value in the mask; one binary mask (255 foreground / 0 background) is
-    produced for **every** entry — no label name is special. ``pixel_mapping`` is the user's
-    own vocabulary; *which* of these classes get sampled is decided downstream by the sampling
-    spec (``min_coverage`` thresholds), not here.
+    produced for every entry. Annotation names are user-defined except for ``"merged"``,
+    which is reserved for structural merged coordinate output, and label IDs must be distinct
+    integers in ``[0, 255]`` regardless of the raster's integer storage width. Which classes
+    get sampled is decided downstream by the sampling spec (``min_coverage`` thresholds), not
+    here.
 
     There is no reserved ``background`` label: every pixel value present in the raster must be
     declared (the read-time discreteness guard rejects undeclared values), so if the raster
@@ -492,6 +495,7 @@ def resolve_annotation_masks(
     """
     if mask_path is None:
         raise ValueError("resolve_annotation_masks requires a mask_path")
+    validate_pixel_mapping(pixel_mapping)
 
     resolved_mask_backend = _resolve_mask_backend(mask_path, mask_backend)
     requested_mask_backend = (

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 
 from hs2p.configs import FilterConfig, PreviewConfig, SegmentationConfig, TilingConfig
-from hs2p.configs.resolvers import require_tissue_fraction
+from hs2p.configs.resolvers import require_tissue_fraction, validate_sampling_spec
 from hs2p.progress import emit_progress, emit_progress_log
 from hs2p.tiling.result import ResolvedTissueMask, TilingResult
 from hs2p.tiling.single import (
@@ -24,7 +24,7 @@ from hs2p.tiling.single import (
     preprocess_slide_per_annotation,
 )
 from hs2p.tiling.tar import _annotation_tar_stem, _needs_pixel_filtering, extract_tiles_to_tar
-from hs2p.fileops import is_flattened_annotation
+from hs2p.fileops import is_flattened_annotation, validate_annotation_name
 from hs2p.wsi import (
     CoordinateOutputMode,
     CoordinateSelectionStrategy,
@@ -369,6 +369,8 @@ def tile_slide(
     """Tile a single slide. With ``sampling`` provided, performs annotation-aware sampling
     and returns one :class:`TilingResult` per active annotation (``{annotation: result}``);
     otherwise tiles tissue and returns a single :class:`TilingResult`."""
+    if sampling is not None:
+        validate_sampling_spec(sampling)
     effective_tiling = _resolve_effective_backends(whole_slide, tiling)
     effective_segmentation = _resolve_effective_segmentation(
         whole_slide=whole_slide,
@@ -486,14 +488,16 @@ def write_annotation_tiling_preview(
     full color as backdrop, with the selected tile grid (fixed black line) drawn over it.
 
     The preview subdirectory mirrors the coordinate artifact path 1:1 via the shared
-    :func:`is_flattened_annotation` rule (per-annotation subdir, except None/"tissue"/merged →
-    flat root). Returns ``None`` for an empty tile set so zero-tile labels skip their preview.
+    :func:`is_flattened_annotation` rule (per-annotation subdir, except structural output
+    ``None`` and conventional ``"tissue"`` → flat root). Returns ``None`` for an empty tile
+    set so zero-tile labels skip their preview.
     """
+    annotation = result.annotation
+    validate_annotation_name(annotation)
     if len(result.x) == 0:
         return None
     save_dir = output_dir / "preview" / "tiling"
     save_dir.mkdir(parents=True, exist_ok=True)
-    annotation = result.annotation
     if is_flattened_annotation(annotation):
         preview_path = save_dir / f"{result.sample_id}.jpg"
         preview_annotation = None
@@ -1181,9 +1185,8 @@ def tile_slides(
     output_mode: str | None = None,
 ) -> list[TilingArtifacts]:
     output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    _validate_whole_slides(whole_slides)
     if sampling is not None:
+        validate_sampling_spec(sampling)
         if not sampling.active_annotations:
             raise ValueError("annotation sampling requires a non-empty sampling.active_annotations")
         unsupported = [
@@ -1200,6 +1203,8 @@ def tile_slides(
                 "tile_slides annotation sampling does not yet support: "
                 + ", ".join(unsupported)
             )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _validate_whole_slides(whole_slides)
     _validate_segmentation_requirement(
         whole_slides=whole_slides,
         segmentation=segmentation,

--- a/hs2p/tiling/single.py
+++ b/hs2p/tiling/single.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import numpy as np
 
+from hs2p.configs.resolvers import validate_pixel_mapping, validate_sampling_spec
 from hs2p.tiling.contours import _normalize_level_downsamples, detect_contours
 from hs2p.tiling.coverage import compute_tile_coverage
 from hs2p.tiling.generate import generate_tiles
@@ -545,6 +546,8 @@ def build_per_annotation_tiling_results(
     INDEPENDENT_SAMPLING: one tiling pass per annotation using that annotation's binary mask.
     JOINT_SAMPLING: one pass on the union mask, then per-annotation post-filter by coverage.
     """
+    validate_sampling_spec(sampling_spec)
+    validate_pixel_mapping(resolved_masks.pixel_mapping)
     if output_mode is None:
         output_mode = CoordinateOutputMode.PER_ANNOTATION
     # Validate here (the shared chokepoint for both the CLI and the public tile_slide/
@@ -768,6 +771,8 @@ def preprocess_slide_per_annotation(
     When ``mask_preview`` is given, one filled multi-label overlay is rendered here — once per
     slide, from the just-resolved per-label binary masks — before any sampling.
     """
+    validate_pixel_mapping(pixel_mapping)
+    validate_sampling_spec(sampling_spec)
     slide = open_slide(image_path, backend=backend, spacing_override=spacing_override)
     try:
         resolved_masks = resolve_annotation_masks(

--- a/hs2p/tiling/tar.py
+++ b/hs2p/tiling/tar.py
@@ -14,7 +14,11 @@ from PIL import Image
 
 from hs2p.tiling.result import TilingResult
 from hs2p.tile_qc import filter_coordinate_tiles, needs_pixel_qc
-from hs2p.fileops import is_flattened_annotation, promote_temp_file
+from hs2p.fileops import (
+    is_flattened_annotation,
+    promote_temp_file,
+    validate_annotation_name,
+)
 from hs2p.wsi import iter_tile_records_from_result, open_reader_for_result
 from hs2p.wsi.reader import BatchRegionReader
 
@@ -124,6 +128,10 @@ def extract_tiles_to_tar(
     gpu_decode: bool = False,
     phase_recorder: Any | None = None,
 ) -> tuple[Path, TilingResult]:
+    from hs2p.artifacts import _annotation_tiles_dir
+
+    validate_annotation_name(annotation)
+    validate_annotation_name(result.annotation)
     jpeg_backend = str(jpeg_backend)
     _jpeg_encoder = None
     if jpeg_backend == "turbojpeg":
@@ -131,7 +139,6 @@ def extract_tiles_to_tar(
 
         _jpeg_encoder = turbojpeg.TurboJPEG()
 
-    from hs2p.artifacts import _annotation_tiles_dir
     tiles_dir = Path(tiles_dir) if tiles_dir is not None else _annotation_tiles_dir(output_dir, annotation)
     tiles_dir.mkdir(parents=True, exist_ok=True)
     stem = _annotation_tar_stem(result.sample_id, annotation)

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -16,7 +16,10 @@ import pandas as pd
 from hs2p.api import FilterConfig, SlideSpec, TilingConfig, tile_slide, tile_slides
 from hs2p.tiling.coverage import summarize_annotation_coverage
 from hs2p.tiling.mask import resolve_annotation_masks
-from hs2p.tiling.single import preprocess_slide_per_annotation
+from hs2p.tiling.single import (
+    build_per_annotation_tiling_results,
+    preprocess_slide_per_annotation,
+)
 from hs2p.wsi.types import CoordinateOutputMode, CoordinateSelectionStrategy, SamplingSpec
 
 BASE_SPACING = 0.5
@@ -125,16 +128,30 @@ def test_resolve_annotation_masks_splits_per_declared_label(patched_mask_open):
     assert resolved.pixel_mapping == PIXEL_MAPPING
 
 
-def test_resolve_annotation_masks_preserves_uint16_labels_above_255(monkeypatch):
-    """Label values above 255 stored in a uint16 raster must not wrap to uint8.
+def test_resolve_annotation_masks_rejects_reserved_name_before_mask_io(monkeypatch):
+    monkeypatch.setattr(
+        maskmod,
+        "_resolve_mask_backend",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("mask backend resolution must not run")
+        ),
+    )
 
-    The reader validates labels against the full pixel-value set (which is not bounded to
-    255), so an unconditional uint8 downcast would wrap e.g. 300 -> 44, silently dropping a
-    class or merging it into whichever class owns the wrapped value.
-    """
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        resolve_annotation_masks(
+            slide=_mock_slide(),
+            mask_path="/fake/slide_mask.tif",
+            pixel_mapping={"background": 0, "merged": 1},
+            seg_downsample=1,
+        )
+
+
+def test_resolve_annotation_masks_accepts_uint16_storage_for_preview_safe_labels(
+    monkeypatch,
+):
     mask = np.zeros((SLIDE_H, SLIDE_W), dtype=np.uint16)
-    mask[0:200, 0:200] = 300  # would wrap to 44 under a uint8 downcast
-    mask[200:400, 200:400] = 600  # would wrap to 88
+    mask[0:200, 0:200] = 254
+    mask[200:400, 200:400] = 255
     monkeypatch.setattr(
         maskmod,
         "open_slide",
@@ -145,7 +162,7 @@ def test_resolve_annotation_masks_preserves_uint16_labels_above_255(monkeypatch)
     resolved = resolve_annotation_masks(
         slide=_mock_slide(),
         mask_path="/fake/slide_mask.tif",
-        pixel_mapping={"background": 0, "tumor": 300, "stroma": 600},
+        pixel_mapping={"background": 0, "tumor": 254, "stroma": 255},
         seg_downsample=1,
     )
     assert int(np.count_nonzero(resolved.masks["tumor"])) == 200 * 200
@@ -353,6 +370,31 @@ def _sampling_spec():
     )
 
 
+def test_build_per_annotation_results_rejects_invalid_declaration_before_slide_io():
+    slide = SimpleNamespace(
+        read_region=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("slide I/O must not run")
+        )
+    )
+    sampling = SamplingSpec(
+        pixel_mapping={"background": 0, "tumor": 256},
+        color_mapping=None,
+        tissue_percentage={"background": None, "tumor": 0.1},
+        active_annotations=("tumor",),
+    )
+
+    with pytest.raises(ValueError, match=r"tumor.*256"):
+        build_per_annotation_tiling_results(
+            slide=slide,
+            resolved_masks=SimpleNamespace(pixel_mapping={"background": 0}),
+            sampling_spec=sampling,
+            selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+            image_path="/fake/slide.tif",
+            backend="mock",
+            requested_backend="mock",
+        )
+
+
 @pytest.fixture
 def patched_slide_and_mask_open(monkeypatch):
     mask = _label_mask()
@@ -403,6 +445,33 @@ def test_preprocess_slide_per_annotation_wires_producer_to_sampler(
     assert (stroma.tiles.x >= 192).all() and (stroma.tiles.y >= 192).all()
 
 
+def test_preprocess_slide_per_annotation_validates_declarations_before_opening_slide(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        singlemod,
+        "open_slide",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("slide must not be opened")
+        ),
+    )
+    sampling = SamplingSpec(
+        pixel_mapping={"background": 0, "merged": 1},
+        color_mapping=None,
+        tissue_percentage={"background": None, "merged": 0.1},
+        active_annotations=("merged",),
+    )
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        preprocess_slide_per_annotation(
+            image_path="/fake/slide.tif",
+            mask_path="/fake/slide_mask.tif",
+            pixel_mapping=sampling.pixel_mapping,
+            sampling_spec=sampling,
+            selection_strategy=CoordinateSelectionStrategy.JOINT_SAMPLING,
+        )
+
+
 def test_tile_slide_with_sampling_returns_per_annotation_dict(monkeypatch):
     """tile_slide(..., sampling=spec) dispatches to the shared annotation core and returns
     one TilingResult per active annotation — same capability as tile_slides (no divergence)."""
@@ -441,6 +510,94 @@ def test_tile_slide_with_sampling_returns_per_annotation_dict(monkeypatch):
     assert isinstance(result, dict)
     assert set(result) == {"tumor", "stroma", "necrosis"}
     assert result["tumor"].num_tiles > 0
+
+
+def test_tile_slide_rejects_invalid_sampling_before_slide_io(monkeypatch):
+    monkeypatch.setattr(
+        orchmod,
+        "resolve_backends",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("slide backend resolution must not run")
+        ),
+    )
+    sampling = SamplingSpec(
+        pixel_mapping={"background": 0, "tumor": 256},
+        color_mapping=None,
+        tissue_percentage={"background": None, "tumor": 0.1},
+        active_annotations=("tumor",),
+    )
+
+    with pytest.raises(ValueError, match=r"tumor.*256"):
+        tile_slide(
+            SlideSpec(
+                sample_id="slide0",
+                image_path="/fake/slide.tif",
+                mask_path="/fake/slide_mask.tif",
+            ),
+            tiling=_mock_tiling(),
+            filtering=FilterConfig(a_t=0),
+            sampling=sampling,
+        )
+
+
+def test_tile_slide_rejects_reserved_active_annotation_before_slide_io(monkeypatch):
+    monkeypatch.setattr(
+        orchmod,
+        "resolve_backends",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("slide backend resolution must not run")
+        ),
+    )
+    sampling = SamplingSpec(
+        pixel_mapping={"background": 0, "tumor": 1},
+        color_mapping=None,
+        tissue_percentage={"background": None, "tumor": 0.1},
+        active_annotations=("merged",),
+    )
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        tile_slide(
+            SlideSpec(
+                sample_id="slide0",
+                image_path="/fake/slide.tif",
+                mask_path="/fake/slide_mask.tif",
+            ),
+            tiling=_mock_tiling(),
+            filtering=FilterConfig(a_t=0),
+            sampling=sampling,
+        )
+
+
+@pytest.mark.parametrize("mapping_name", ["tissue_percentage", "color_mapping"])
+def test_tile_slide_rejects_reserved_name_in_sampling_mapping_before_slide_io(
+    monkeypatch, mapping_name
+):
+    monkeypatch.setattr(
+        orchmod,
+        "resolve_backends",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("slide backend resolution must not run")
+        ),
+    )
+    sampling_kwargs = {
+        "pixel_mapping": {"background": 0, "tumor": 1},
+        "color_mapping": None,
+        "tissue_percentage": {"background": None, "tumor": 0.1},
+        "active_annotations": ("tumor",),
+    }
+    sampling_kwargs[mapping_name] = {"merged": None}
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        tile_slide(
+            SlideSpec(
+                sample_id="slide0",
+                image_path="/fake/slide.tif",
+                mask_path="/fake/slide_mask.tif",
+            ),
+            tiling=_mock_tiling(),
+            filtering=FilterConfig(a_t=0),
+            sampling=SamplingSpec(**sampling_kwargs),
+        )
 
 
 @pytest.mark.parametrize(
@@ -592,6 +749,11 @@ def test_tile_slides_merged_emits_one_artifact_per_slide(monkeypatch, tmp_path):
     assert len(artifacts) == 2  # one per slide, not per (slide, annotation)
     assert {a.sample_id for a in artifacts} == {"slide0", "slide1"}
     assert all(a.annotation is None for a in artifacts)
+    assert all(
+        artifact.coordinates_meta_path.parent == tmp_path / "tiles"
+        for artifact in artifacts
+    )
+    assert not (tmp_path / "tiles" / "merged").exists()
 
     rows = pd.read_csv(tmp_path / "process_list.csv")
     assert len(rows) == 2
@@ -621,6 +783,67 @@ def test_tile_slides_sampling_rejects_unsupported_combos(monkeypatch, tmp_path, 
             sampling=_sampling_spec(),
             **kwargs,
         )
+
+
+def test_tile_slides_rejects_reserved_annotation_before_slide_io_or_output(
+    monkeypatch, tmp_path
+):
+    output_dir = tmp_path / "output"
+    monkeypatch.setattr(
+        orchmod,
+        "resolve_backends",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("slide backend resolution must not run")
+        ),
+    )
+    sampling = SamplingSpec(
+        pixel_mapping={"background": 0, "merged": 1},
+        color_mapping=None,
+        tissue_percentage={"background": None, "merged": 0.1},
+        active_annotations=("merged",),
+    )
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        tile_slides(
+            _slides(1),
+            tiling=_mock_tiling(),
+            filtering=FilterConfig(a_t=0),
+            output_dir=output_dir,
+            sampling=sampling,
+        )
+
+    assert not output_dir.exists()
+
+
+@pytest.mark.parametrize("invalid_value", [-1, 256])
+def test_tile_slides_rejects_invalid_label_id_before_slide_io_or_output(
+    monkeypatch, tmp_path, invalid_value
+):
+    output_dir = tmp_path / "output"
+    monkeypatch.setattr(
+        orchmod,
+        "resolve_backends",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("slide backend resolution must not run")
+        ),
+    )
+    sampling = SamplingSpec(
+        pixel_mapping={"background": 0, "tumor": invalid_value},
+        color_mapping=None,
+        tissue_percentage={"background": None, "tumor": 0.1},
+        active_annotations=("tumor",),
+    )
+
+    with pytest.raises(ValueError, match=rf"tumor.*{invalid_value}"):
+        tile_slides(
+            _slides(1),
+            tiling=_mock_tiling(),
+            filtering=FilterConfig(a_t=0),
+            output_dir=output_dir,
+            sampling=sampling,
+        )
+
+    assert not output_dir.exists()
 
 
 def _sampling_spec_with_colors():

--- a/tests/test_annotation_path_flattening.py
+++ b/tests/test_annotation_path_flattening.py
@@ -1,20 +1,21 @@
-"""The annotation→path flattening rule (None/tissue/merged → flat root, other labels → a
-per-annotation subdir) must live in a single shared helper that both the artifact code
-and the preview/visualization layer can import without a circular import."""
+"""Structural output (None) and conventional tissue annotations stay flat, while named
+annotations use per-annotation subdirectories."""
 
 import pytest
 
 from hs2p.fileops import is_flattened_annotation
 
 
-@pytest.mark.parametrize("annotation", [None, "tissue", "merged"])
-def test_flattened_for_none_tissue_and_merged(annotation):
-    # "merged" is the union-of-classes output mode: it carries no single class label, so
-    # its artifacts belong at the flat root alongside plain tissue (not a `merged/` subdir).
+@pytest.mark.parametrize("annotation", [None, "tissue"])
+def test_flattened_for_structural_output_and_tissue(annotation):
+    # Structural merged output carries annotation=None and output_mode="merged".
     assert is_flattened_annotation(annotation) is True
 
 
-@pytest.mark.parametrize("annotation", ["grade_4", "tumor", "Tissue", "tissue_x", "Merged", "merged_x"])
+@pytest.mark.parametrize(
+    "annotation",
+    ["grade_4", "tumor", "Tissue", "tissue_x", "merged", "Merged", "merged_x"],
+)
 def test_not_flattened_for_named_labels(annotation):
     assert is_flattened_annotation(annotation) is False
 

--- a/tests/test_annotation_path_safety.py
+++ b/tests/test_annotation_path_safety.py
@@ -18,6 +18,11 @@ def test_annotation_tiles_dir_subdir_for_named_class(tmp_path):
     assert _annotation_tiles_dir(tmp_path, "grade_4") == tmp_path / "tiles" / "grade_4"
 
 
+def test_annotation_tiles_dir_rejects_reserved_merged_name(tmp_path):
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        _annotation_tiles_dir(tmp_path, "merged")
+
+
 @pytest.mark.parametrize("bad", ["../outside", "/tmp/owned", "a/b", "..", ".", "x\\y", ""])
 def test_annotation_tiles_dir_rejects_traversal(tmp_path, bad):
     with pytest.raises(ValueError, match="path component"):

--- a/tests/test_overlay_semantics.py
+++ b/tests/test_overlay_semantics.py
@@ -399,6 +399,41 @@ def test_write_annotation_tiling_preview_draws_label_backdrop_under_black_grid(
     assert arr[0, 0].max() <= 20
 
 
+def test_write_annotation_tiling_preview_rejects_reserved_name_before_writing(
+    monkeypatch, tmp_path: Path
+):
+    orchestration_mod = pytest.importorskip("hs2p.tiling.orchestration")
+    monkeypatch.setattr(
+        orchestration_mod,
+        "write_coordinate_preview",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("preview writer must not run")
+        ),
+    )
+    result = SimpleNamespace(
+        x=np.array([0], dtype=np.int64),
+        y=np.array([0], dtype=np.int64),
+        tile_size_lv0=64,
+        image_path=Path("fake-wsi.tif"),
+        backend="openslide",
+        sample_id="slide0",
+        annotation="merged",
+        mask_backend=None,
+    )
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        orchestration_mod.write_annotation_tiling_preview(
+            result=result,
+            output_dir=tmp_path,
+            downsample=1,
+            mask_path=None,
+            pixel_mapping=None,
+            color_mapping=None,
+        )
+
+    assert not (tmp_path / "preview").exists()
+
+
 def test_save_overlay_preview_writes_rgba_overlay_to_jpeg(monkeypatch, tmp_path: Path):
     overlay = Image.fromarray(
         np.array(

--- a/tests/test_sampling_color_mapping_validation.py
+++ b/tests/test_sampling_color_mapping_validation.py
@@ -3,9 +3,8 @@ import pytest
 from hs2p.configs.resolvers import validate_color_mapping, validate_pixel_mapping
 
 
-def test_validate_pixel_mapping_accepts_uint16_labels_without_background():
-    # background is optional, and values up to the uint16 ceiling are allowed
-    validate_pixel_mapping({"grade_4": 300, "grade_5": 600})
+def test_validate_pixel_mapping_accepts_preview_safe_boundaries_without_background():
+    validate_pixel_mapping({"grade_4": 0, "grade_5": 255})
 
 
 def test_validate_pixel_mapping_rejects_duplicate_values():
@@ -13,11 +12,13 @@ def test_validate_pixel_mapping_rejects_duplicate_values():
         validate_pixel_mapping({"background": 0, "tumor": 1, "stroma": 1})
 
 
-def test_validate_pixel_mapping_rejects_out_of_range_values():
-    with pytest.raises(ValueError, match="range"):
-        validate_pixel_mapping({"background": 0, "tumor": 70000})
-    with pytest.raises(ValueError, match="range"):
-        validate_pixel_mapping({"background": 0, "tumor": -1})
+@pytest.mark.parametrize("invalid_value", [-1, 256])
+def test_validate_pixel_mapping_rejects_value_outside_preview_safe_range(invalid_value):
+    with pytest.raises(
+        ValueError,
+        match=rf"tumor.*{invalid_value}.*range \[0, 255\]",
+    ):
+        validate_pixel_mapping({"background": 0, "tumor": invalid_value})
 
 
 def test_validate_pixel_mapping_rejects_non_integer_values():

--- a/tests/test_sampling_request_resolution.py
+++ b/tests/test_sampling_request_resolution.py
@@ -123,6 +123,58 @@ def test_background_label_is_not_reserved_at_activation():
     assert set(sampling.active_annotations) == {"background"}
 
 
+def test_annotation_config_rejects_reserved_merged_name():
+    cfg = _cfg(
+        {
+            "tiling": {
+                "masks": {
+                    "pixel_mapping": {"merged": 2},
+                    "colors": {"merged": None},
+                    "min_coverage": {"merged": 0.5},
+                }
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        resolve_sampling_request(cfg, tiling=resolve_tiling_config(cfg))
+
+
+def test_annotation_config_rejects_reserved_name_before_null_to_drop():
+    cfg = _cfg(
+        {
+            "tiling": {
+                "masks": {
+                    "pixel_mapping": {"merged": None},
+                    "colors": {"merged": None},
+                    "min_coverage": {"merged": 0.5},
+                }
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        resolve_sampling_request(cfg, tiling=resolve_tiling_config(cfg))
+
+
+@pytest.mark.parametrize("invalid_value", [-1, 256])
+def test_annotation_config_rejects_label_id_outside_preview_safe_range(invalid_value):
+    cfg = _cfg(
+        {
+            "tiling": {
+                "masks": {
+                    "pixel_mapping": {"tumor": invalid_value},
+                    "colors": {"tumor": None},
+                    "min_coverage": {"tumor": 0.5},
+                }
+            }
+        }
+    )
+
+    with pytest.raises(ValueError, match=rf"tumor.*{invalid_value}"):
+        resolve_sampling_request(cfg, tiling=resolve_tiling_config(cfg))
+
+
 def test_build_default_sampling_spec_requires_tissue_coverage():
     """The binary-tissue default spec hard-errors on a missing tissue threshold (no silent
     0.0), honours an explicit 0.0 opt-out, and carries a specified value through."""

--- a/tests/test_tile_extraction.py
+++ b/tests/test_tile_extraction.py
@@ -93,6 +93,33 @@ def _solid_patch(color: tuple[int, int, int], size: int = 256) -> np.ndarray:
     return arr
 
 
+def test_extract_tiles_to_tar_rejects_reserved_annotation_before_writing(tmp_path):
+    output_dir = tmp_path / "output"
+    tiles_dir = tmp_path / "explicit-tiles"
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        extract_tiles_to_tar(
+            _make_tiling_result(num_tiles=0),
+            output_dir,
+            annotation="merged",
+            tiles_dir=tiles_dir,
+        )
+
+    assert not output_dir.exists()
+    assert not tiles_dir.exists()
+
+
+def test_extract_tiles_to_tar_rejects_reserved_result_annotation_before_writing(
+    tmp_path,
+):
+    result = replace(_make_tiling_result(num_tiles=0), annotation="merged")
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        extract_tiles_to_tar(result, tmp_path)
+
+    assert not (tmp_path / "tiles").exists()
+
+
 def _make_grid_tiling_result(
     *,
     columns: int,

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -789,6 +789,43 @@ def test_save_and_load_tiling_result_round_trip(tmp_path: Path):
     np.testing.assert_array_equal(loaded.tissue_fractions, result.tissue_fractions)
 
 
+def test_save_tiling_result_rejects_reserved_annotation_with_explicit_tiles_dir(
+    tmp_path: Path,
+):
+    result = _build_preprocessing_result(
+        sample_id="slide-reserved",
+        image_path="slide-reserved.svs",
+    )
+    output_dir = tmp_path / "output"
+    tiles_dir = tmp_path / "explicit-tiles"
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        save_tiling_result(
+            result,
+            output_dir=output_dir,
+            annotation="merged",
+            tiles_dir=tiles_dir,
+        )
+
+    assert not output_dir.exists()
+    assert not tiles_dir.exists()
+
+
+def test_save_tiling_result_rejects_reserved_result_annotation_before_writing(
+    tmp_path: Path,
+):
+    result = _build_preprocessing_result(
+        sample_id="slide-reserved",
+        image_path="slide-reserved.svs",
+        annotation="merged",
+    )
+
+    with pytest.raises(ValueError, match="'merged'.*reserved"):
+        save_tiling_result(result, output_dir=tmp_path)
+
+    assert not (tmp_path / "tiles").exists()
+
+
 def test_preprocessing_result_builder_preserves_core_fields():
     result = _build_preprocessing_result(
         sample_id="slide-adapter",


### PR DESCRIPTION
## Summary

- reserve `merged` for structural merged coordinate output across configuration, direct Python sampling, and artifact-writing boundaries
- restrict declared annotation label IDs to `0..255` while continuing to accept wider integer mask storage when decoded values stay in range
- preserve flat structural merged output and the conventional flat `tissue` annotation layout
- document the reserved identity and supported value range

## Why

Annotation declarations previously accepted the structural `merged` identity and values through the `uint16` ceiling. This could collide with merged-output layout semantics and expose labels that preview consumers cannot represent safely.

## Impact

Invalid declarations now fail with the annotation name and invalid value before slide/backend I/O or output creation. No label value is silently cast, wrapped, or remapped.

## Validation

- focused issue suite: `201 passed`
- full suite: `390 passed, 3 skipped, 46 deselected` (6 existing dependency warnings)
- two-axis `/code-review main`: all Standards and Spec findings fixed and re-reviewed; no remaining actionable finding
- `git diff --check`: passed

Closes #173