### PR TITLE
Make Pillow the portable default tile encoder

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -6,6 +6,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  wheel-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build --wheel
+
+      - name: Test base wheel tile saving
+        run: |
+          python -m venv /tmp/hs2p-wheel-smoke
+          /tmp/hs2p-wheel-smoke/bin/python -m pip install dist/*.whl
+          cd /tmp
+          /tmp/hs2p-wheel-smoke/bin/python "$GITHUB_WORKSPACE/scripts/smoke_tile_wheel.py"
+
   docker-test:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -36,8 +36,15 @@ pip install "hs2p[openslide]"
 pip install "hs2p[asap]"
 pip install "hs2p[vips]"
 pip install "hs2p[cucim]"
+pip install "hs2p[turbojpeg]"
 pip install "hs2p[all]"
 ```
+
+Tile TAR export uses Pillow (`speed.jpeg_backend: pil`) by default, so it works
+with the base install. For higher JPEG encoding throughput, install the
+`turbojpeg` extra and explicitly set `speed.jpeg_backend: turbojpeg`. Explicit
+encoder choices are authoritative: hs2p reports a missing optional dependency
+instead of falling back to a different encoder.
 
 The supported backend set is:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,8 +72,13 @@ pip install "hs2p[openslide]"
 pip install "hs2p[asap]"
 pip install "hs2p[vips]"
 pip install "hs2p[cucim]"
+pip install "hs2p[turbojpeg]"
 pip install "hs2p[all]"
 ```
+
+The base install includes Pillow, the portable default JPEG encoder for tile TAR
+export. The `turbojpeg` extra installs PyTurboJPEG as an optional performance
+backend and is also included in `all`.
 
 `tiling.backend` (slide reader) and `tiling.mask_backend` (source-mask reader) both support:
 
@@ -161,6 +166,12 @@ backend fields/columns) are rejected clearly rather than loaded.
   - write `tiles/{sample_id}.tiles.tar`
 - `speed.num_workers`
   - slide-level batch parallelism
+- `speed.jpeg_backend`
+  - `pil` (default) uses the core Pillow dependency and works in a base install
+  - `turbojpeg` opts into the faster PyTurboJPEG encoder and requires
+    `pip install "hs2p[turbojpeg]"`
+  - explicit selections never fall back; an unavailable TurboJPEG dependency is
+    reported before slide tile extraction begins
 
 ## Progress reporting
 

--- a/hs2p/__main__.py
+++ b/hs2p/__main__.py
@@ -59,7 +59,7 @@ def main(args):
             sampling, selection_strategy, output_mode = resolve_sampling_request(
                 cfg, tiling=tiling
             )
-            jpeg_backend = str(getattr(cfg.speed, "jpeg_backend", "turbojpeg"))
+            jpeg_backend = str(getattr(cfg.speed, "jpeg_backend", "pil"))
             progress.emit_progress(
                 "run.started",
                 command="tiling",

--- a/hs2p/__main__.py
+++ b/hs2p/__main__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import hs2p.progress as progress
 from hs2p.api import tile_slides
+from hs2p.configs.loader import DEFAULT_JPEG_BACKEND
 from hs2p.configs.resolvers import (
     resolve_filter_config,
     resolve_preview_config,
@@ -59,7 +60,9 @@ def main(args):
             sampling, selection_strategy, output_mode = resolve_sampling_request(
                 cfg, tiling=tiling
             )
-            jpeg_backend = str(getattr(cfg.speed, "jpeg_backend", "pil"))
+            jpeg_backend = str(
+                getattr(cfg.speed, "jpeg_backend", DEFAULT_JPEG_BACKEND)
+            )
             progress.emit_progress(
                 "run.started",
                 command="tiling",

--- a/hs2p/configs/default.yaml
+++ b/hs2p/configs/default.yaml
@@ -78,7 +78,7 @@ tiling:
 
 speed:
   num_workers: 8 # number of workers for tiling slides
-  jpeg_backend: "turbojpeg" # JPEG encoder used when saving tiles
+  jpeg_backend: "pil" # portable default; use turbojpeg with hs2p[turbojpeg] for faster tile encoding
 
 wandb:
   enable: false

--- a/hs2p/configs/loader.py
+++ b/hs2p/configs/loader.py
@@ -9,6 +9,7 @@ def load_config(config_name: str):
 
 
 default_config = load_config("default")
+DEFAULT_JPEG_BACKEND = str(default_config.speed.jpeg_backend)
 
 
 def load_and_merge_config(config_name: str):

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 
 from hs2p.configs import FilterConfig, PreviewConfig, SegmentationConfig, TilingConfig
+from hs2p.configs.loader import DEFAULT_JPEG_BACKEND
 from hs2p.configs.resolvers import require_tissue_fraction, validate_sampling_spec
 from hs2p.progress import emit_progress, emit_progress_log
 from hs2p.tiling.result import ResolvedTissueMask, TilingResult
@@ -569,7 +570,7 @@ class _ComputeRequest:
     preview_downsample: int = 32
     mask_overlay_color: tuple[int, int, int] = (157, 219, 129)
     mask_overlay_alpha: float = 0.5
-    jpeg_backend: str = "pil"
+    jpeg_backend: str = DEFAULT_JPEG_BACKEND
     gpu_decode: bool = False
     include_result: bool = False
     save_tiles: bool = False
@@ -1182,7 +1183,7 @@ def tile_slides(
     resume: bool = False,
     read_coordinates_from: Path | None = None,
     save_tiles: bool = False,
-    jpeg_backend: str = "pil",
+    jpeg_backend: str = DEFAULT_JPEG_BACKEND,
     gpu_decode: bool = False,
     sampling: SamplingSpec | None = None,
     selection_strategy: str | None = None,

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -23,7 +23,11 @@ from hs2p.tiling.single import (
     preprocess_slide,
     preprocess_slide_per_annotation,
 )
-from hs2p.tiling.tar import _annotation_tar_stem, _needs_pixel_filtering, extract_tiles_to_tar
+from hs2p.tiling.tar import (
+    _load_jpeg_backend,
+    _needs_pixel_filtering,
+    extract_tiles_to_tar,
+)
 from hs2p.fileops import is_flattened_annotation, validate_annotation_name
 from hs2p.wsi import (
     CoordinateOutputMode,
@@ -565,7 +569,7 @@ class _ComputeRequest:
     preview_downsample: int = 32
     mask_overlay_color: tuple[int, int, int] = (157, 219, 129)
     mask_overlay_alpha: float = 0.5
-    jpeg_backend: str = "turbojpeg"
+    jpeg_backend: str = "pil"
     gpu_decode: bool = False
     include_result: bool = False
     save_tiles: bool = False
@@ -1178,7 +1182,7 @@ def tile_slides(
     resume: bool = False,
     read_coordinates_from: Path | None = None,
     save_tiles: bool = False,
-    jpeg_backend: str = "turbojpeg",
+    jpeg_backend: str = "pil",
     gpu_decode: bool = False,
     sampling: SamplingSpec | None = None,
     selection_strategy: str | None = None,
@@ -1209,6 +1213,8 @@ def tile_slides(
         whole_slides=whole_slides,
         segmentation=segmentation,
     )
+    if save_tiles:
+        _load_jpeg_backend(str(jpeg_backend))
     artifacts: list[TilingArtifacts] = []
     process_rows: list[dict[str, Any]] = []
     process_list_path = output_dir / "process_list.csv"

--- a/hs2p/tiling/tar.py
+++ b/hs2p/tiling/tar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import importlib
 import io
 import tarfile
 import tempfile
@@ -21,6 +22,22 @@ from hs2p.fileops import (
 )
 from hs2p.wsi import iter_tile_records_from_result, open_reader_for_result
 from hs2p.wsi.reader import BatchRegionReader
+
+
+def _load_jpeg_backend(jpeg_backend: str) -> Any | None:
+    if jpeg_backend == "pil":
+        return None
+    if jpeg_backend != "turbojpeg":
+        raise ValueError(f"Unsupported jpeg_backend: {jpeg_backend}")
+    try:
+        return importlib.import_module("turbojpeg")
+    except ModuleNotFoundError as exc:
+        if exc.name != "turbojpeg":
+            raise
+        raise ImportError(
+            "JPEG backend 'turbojpeg' requires the optional PyTurboJPEG "
+            "dependency; install it with pip install 'hs2p[turbojpeg]'."
+        ) from exc
 
 
 def _annotation_tar_stem(sample_id: str, annotation: str | None) -> str:
@@ -120,7 +137,7 @@ def extract_tiles_to_tar(
     *,
     annotation: str | None = None,
     jpeg_quality: int = 90,
-    jpeg_backend: str = "turbojpeg",
+    jpeg_backend: str = "pil",
     supertile_sizes: Sequence[int] | None = None,
     tiles_dir: Path | None = None,
     filter_params: Any | None = None,
@@ -133,11 +150,8 @@ def extract_tiles_to_tar(
     validate_annotation_name(annotation)
     validate_annotation_name(result.annotation)
     jpeg_backend = str(jpeg_backend)
-    _jpeg_encoder = None
-    if jpeg_backend == "turbojpeg":
-        import turbojpeg
-
-        _jpeg_encoder = turbojpeg.TurboJPEG()
+    turbojpeg = _load_jpeg_backend(jpeg_backend)
+    _jpeg_encoder = turbojpeg.TurboJPEG() if turbojpeg is not None else None
 
     tiles_dir = Path(tiles_dir) if tiles_dir is not None else _annotation_tiles_dir(output_dir, annotation)
     tiles_dir.mkdir(parents=True, exist_ok=True)
@@ -206,6 +220,7 @@ def extract_tiles_to_tar(
 
                 if jpeg_backend == "turbojpeg":
                     assert _jpeg_encoder is not None
+                    assert turbojpeg is not None
                     jpeg_bytes = _jpeg_encoder.encode(
                         tile_arr,
                         quality=jpeg_quality,
@@ -217,8 +232,6 @@ def extract_tiles_to_tar(
                     buf = io.BytesIO()
                     img.save(buf, format="JPEG", quality=jpeg_quality)
                     jpeg_bytes = buf.getvalue()
-                else:
-                    raise ValueError(f"Unsupported jpeg_backend: {jpeg_backend}")
                 buf = io.BytesIO(jpeg_bytes)
                 encode_duration = time.perf_counter() - encode_start
                 if phase_recorder is not None:

--- a/hs2p/tiling/tar.py
+++ b/hs2p/tiling/tar.py
@@ -219,16 +219,15 @@ def extract_tiles_to_tar(
                     )
                     tile_arr = np.asarray(img)
 
-                if jpeg_backend == "turbojpeg":
+                if turbojpeg is not None:
                     assert _jpeg_encoder is not None
-                    assert turbojpeg is not None
                     jpeg_bytes = _jpeg_encoder.encode(
                         tile_arr,
                         quality=jpeg_quality,
                         pixel_format=turbojpeg.TJPF_RGB,
                         jpeg_subsample=turbojpeg.TJSAMP_420,
                     )
-                elif jpeg_backend == "pil":
+                else:
                     img = Image.fromarray(tile_arr).convert("RGB")
                     buf = io.BytesIO()
                     img.save(buf, format="JPEG", quality=jpeg_quality)

--- a/hs2p/tiling/tar.py
+++ b/hs2p/tiling/tar.py
@@ -13,6 +13,7 @@ from typing import Any, Sequence
 import numpy as np
 from PIL import Image
 
+from hs2p.configs.loader import DEFAULT_JPEG_BACKEND
 from hs2p.tiling.result import TilingResult
 from hs2p.tile_qc import filter_coordinate_tiles, needs_pixel_qc
 from hs2p.fileops import (
@@ -137,7 +138,7 @@ def extract_tiles_to_tar(
     *,
     annotation: str | None = None,
     jpeg_quality: int = 90,
-    jpeg_backend: str = "pil",
+    jpeg_backend: str = DEFAULT_JPEG_BACKEND,
     supertile_sizes: Sequence[int] | None = None,
     tiles_dir: Path | None = None,
     filter_params: Any | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ cucim = [
 vips = [
     "pyvips",
 ]
+turbojpeg = [
+    "PyTurboJPEG",
+]
 all = [
     "openslide-python",
     "openslide-bin",
@@ -66,6 +69,7 @@ all = [
     "cupy-cuda12x",
     "nvidia-nvimgcodec-cu12>=0.7.0",
     "pyvips",
+    "PyTurboJPEG",
 ]
 testing = [
     "pytest>=6.0",

--- a/scripts/smoke_tile_wheel.py
+++ b/scripts/smoke_tile_wheel.py
@@ -1,0 +1,82 @@
+"""Smoke-test tile saving from an installed base hs2p wheel."""
+
+from __future__ import annotations
+
+import csv
+import importlib.metadata
+import importlib.util
+import io
+import tarfile
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+from PIL import Image
+
+import hs2p
+from hs2p.api import extract_tiles_to_tar
+from hs2p.configs import default_config
+
+
+def main() -> None:
+    assert "site-packages" in str(Path(hs2p.__file__).resolve())
+    assert importlib.util.find_spec("turbojpeg") is None
+    assert default_config.speed.jpeg_backend == "pil"
+
+    metadata = importlib.metadata.metadata("hs2p")
+    extras = set(metadata.get_all("Provides-Extra") or [])
+    requirements = metadata.get_all("Requires-Dist") or []
+    assert "turbojpeg" in extras
+    assert any(
+        requirement.startswith("PyTurboJPEG")
+        and 'extra == "turbojpeg"' in requirement
+        for requirement in requirements
+    )
+    assert any(
+        requirement.startswith("PyTurboJPEG") and 'extra == "all"' in requirement
+        for requirement in requirements
+    )
+
+    tile = np.empty((8, 8, 3), dtype=np.uint8)
+    tile[:] = (12, 34, 56)
+    result = SimpleNamespace(
+        sample_id="wheel-smoke",
+        read_tile_size_px=8,
+        requested_tile_size_px=8,
+        tile_index=np.array([0], dtype=np.int32),
+        x=np.array([0], dtype=np.int64),
+        y=np.array([0], dtype=np.int64),
+    )
+    record = SimpleNamespace(tile_arr=tile, tile_index=0, x=0, y=0)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_dir = Path(temp_dir)
+        with patch(
+            "hs2p.tiling.tar.iter_tile_records_from_result",
+            return_value=iter([record]),
+        ):
+            tar_path, output_result = extract_tiles_to_tar(result, output_dir)
+
+        assert output_result is result
+        with tarfile.open(tar_path) as archive:
+            assert archive.getnames() == ["000000.jpg"]
+            member = archive.extractfile("000000.jpg")
+            assert member is not None
+            with Image.open(io.BytesIO(member.read())) as image:
+                assert image.format == "JPEG"
+                assert image.mode == "RGB"
+                assert image.size == (8, 8)
+
+        manifest_path = output_dir / "tiles" / "wheel-smoke.tiles.manifest.csv"
+        with manifest_path.open(newline="") as handle:
+            assert list(csv.DictReader(handle)) == [
+                {"tile_index": "0", "x": "0", "y": "0"}
+            ]
+
+    print("Clean-wheel Pillow tile smoke check passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_tile_wheel.py
+++ b/scripts/smoke_tile_wheel.py
@@ -43,6 +43,7 @@ def main() -> None:
     tile[:] = (12, 34, 56)
     result = SimpleNamespace(
         sample_id="wheel-smoke",
+        annotation=None,
         read_tile_size_px=8,
         requested_tile_size_px=8,
         tile_index=np.array([0], dtype=np.int32),

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -24,7 +24,7 @@ def _base_cfg(tmp_path: Path, csv_path: Path) -> SimpleNamespace:
         output_dir=str(tmp_path / "output"),
         resume=False,
         save_tiles=False,
-        speed=SimpleNamespace(num_workers=1, jpeg_backend="turbojpeg"),
+        speed=SimpleNamespace(num_workers=1),
         tiling=SimpleNamespace(
             read_coordinates_from=None,
             backend="asap",
@@ -143,7 +143,7 @@ def test_tiling_main_smoke_uses_current_schema_and_manifest(
         )
     ]
     assert captured["save_tiles"] is False
-    assert captured["jpeg_backend"] == "turbojpeg"
+    assert captured["jpeg_backend"] == "pil"
     process_df = pd.read_csv(Path(cfg.output_dir) / "process_list.csv")
     assert list(process_df.columns) == [
         "sample_id",

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -1,7 +1,12 @@
 from pathlib import Path
 from types import SimpleNamespace
 
+from hs2p.configs import default_config
 from hs2p.utils.setup import get_cfg_from_args
+
+
+def test_shipped_config_defaults_to_pillow_jpeg_encoding():
+    assert default_config.speed.jpeg_backend == "pil"
 
 
 def test_get_cfg_from_args_merges_mask_coverage_mapping(tmp_path: Path):

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,5 +1,9 @@
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
 
 def test_turbojpeg_extra_is_dedicated_and_included_in_all():

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,13 @@
+import tomllib
+from pathlib import Path
+
+
+def test_turbojpeg_extra_is_dedicated_and_included_in_all():
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        optional_dependencies = tomllib.load(handle)["project"][
+            "optional-dependencies"
+        ]
+
+    assert optional_dependencies["turbojpeg"] == ["PyTurboJPEG"]
+    assert "PyTurboJPEG" in optional_dependencies["all"]

--- a/tests/test_tile_extraction.py
+++ b/tests/test_tile_extraction.py
@@ -20,14 +20,6 @@ from hs2p.wsi import iter_tile_arrays_from_result
 from hs2p.wsi.streaming.plans import GroupedReadPlan, iter_grouped_read_plans
 
 
-_extract_tiles_to_tar = extract_tiles_to_tar
-
-
-def extract_tiles_to_tar(*args, **kwargs):
-    kwargs.setdefault("jpeg_backend", "pil")
-    return _extract_tiles_to_tar(*args, **kwargs)
-
-
 def _make_tiling_result(
     num_tiles: int = 3,
     tile_size: int = 256,
@@ -443,7 +435,11 @@ class TestExtractTilesToTar:
         )
 
         with patch("hs2p.wsi.streaming.stream.open_slide", return_value=mock_reader):
-            tar_path, _ = _extract_tiles_to_tar(result, output_dir=tmp_path)
+            tar_path, _ = extract_tiles_to_tar(
+                result,
+                output_dir=tmp_path,
+                jpeg_backend="turbojpeg",
+            )
 
         assert tar_path.is_file()
         assert captured == {
@@ -451,6 +447,23 @@ class TestExtractTilesToTar:
             "pixel_format": 0,
             "jpeg_subsample": 2,
         }
+
+    def test_missing_turbojpeg_fails_actionably_before_tile_materialization(
+        self, tmp_path: Path
+    ):
+        result = _make_tiling_result(num_tiles=1)
+
+        with pytest.raises(
+            ImportError,
+            match=r"pip install 'hs2p\[turbojpeg\]'",
+        ):
+            extract_tiles_to_tar(
+                result,
+                output_dir=tmp_path,
+                jpeg_backend="turbojpeg",
+            )
+
+        assert not (tmp_path / "tiles").exists()
 
     def test_uses_pil_encoding_when_requested(self, tmp_path: Path, monkeypatch):
         result = _make_tiling_result(num_tiles=1)

--- a/tests/test_tile_extraction.py
+++ b/tests/test_tile_extraction.py
@@ -14,6 +14,7 @@ import pytest
 from PIL import Image
 
 import hs2p.preprocessing as preprocessing_mod
+import hs2p.tiling.tar as tar_mod
 from hs2p.api import extract_tiles_to_tar
 from hs2p.configs.models import FilterConfig
 from hs2p.wsi import iter_tile_arrays_from_result
@@ -449,9 +450,20 @@ class TestExtractTilesToTar:
         }
 
     def test_missing_turbojpeg_fails_actionably_before_tile_materialization(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch
     ):
         result = _make_tiling_result(num_tiles=1)
+        original_import_module = tar_mod.importlib.import_module
+
+        def _import_module(name):
+            if name == "turbojpeg":
+                raise ModuleNotFoundError(
+                    "No module named 'turbojpeg'",
+                    name="turbojpeg",
+                )
+            return original_import_module(name)
+
+        monkeypatch.setattr(tar_mod.importlib, "import_module", _import_module)
 
         with pytest.raises(
             ImportError,

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -1196,10 +1196,11 @@ def test_tile_slides_assigns_inner_workers_when_batch_is_small(
     segmentation_config: SegmentationConfig,
     filter_config: FilterConfig,
 ):
-    seen = {"pool_processes": None, "inner_workers": []}
+    seen = {"pool_processes": None, "inner_workers": [], "jpeg_backends": []}
 
     def _fake_compute_and_save(request):
         seen["inner_workers"].append(request.num_workers)
+        seen["jpeg_backends"].append(request.jpeg_backend)
         tiles_dir = Path(request.output_dir) / "tiles"
         tiles_dir.mkdir(parents=True, exist_ok=True)
         npz_path = tiles_dir / f"{request.whole_slide.sample_id}.coordinates.npz"
@@ -1261,6 +1262,37 @@ def test_tile_slides_assigns_inner_workers_when_batch_is_small(
 
     assert seen["pool_processes"] == 2
     assert seen["inner_workers"] == [4, 4]
+    assert seen["jpeg_backends"] == ["pil", "pil"]
+
+
+def test_tile_slides_rejects_missing_turbojpeg_before_slide_compute(
+    monkeypatch,
+    tmp_path: Path,
+    tiling_config: TilingConfig,
+    segmentation_config: SegmentationConfig,
+    filter_config: FilterConfig,
+):
+    monkeypatch.setattr(
+        orchestration_mod,
+        "_compute_and_save_tiling_artifacts_from_request",
+        lambda request: pytest.fail(
+            f"slide computation started for {request.whole_slide.sample_id}"
+        ),
+    )
+
+    with pytest.raises(
+        ImportError,
+        match=r"pip install 'hs2p\[turbojpeg\]'",
+    ):
+        tile_slides(
+            [SlideSpec(sample_id="slide-1", image_path=Path("slide-1.svs"))],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=tmp_path,
+            save_tiles=True,
+            jpeg_backend="turbojpeg",
+        )
 
 
 def test_compute_request_passes_inner_workers_to_tile_extraction(

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -1272,6 +1272,17 @@ def test_tile_slides_rejects_missing_turbojpeg_before_slide_compute(
     segmentation_config: SegmentationConfig,
     filter_config: FilterConfig,
 ):
+    def _missing_turbojpeg(_jpeg_backend):
+        raise ImportError(
+            "JPEG backend 'turbojpeg' requires the optional PyTurboJPEG "
+            "dependency; install it with pip install 'hs2p[turbojpeg]'."
+        )
+
+    monkeypatch.setattr(
+        orchestration_mod,
+        "_load_jpeg_backend",
+        _missing_turbojpeg,
+    )
     monkeypatch.setattr(
         orchestration_mod,
         "_compute_and_save_tiling_artifacts_from_request",


### PR DESCRIPTION
## Summary

- make Pillow the shared default JPEG backend for shipped configuration, CLI fallback, and public Python tile-saving APIs
- keep TurboJPEG explicit and authoritative, with an actionable fail-fast error before slide computation or tile materialization when PyTurboJPEG is unavailable
- add the dedicated `turbojpeg` extra with `PyTurboJPEG` and include it in `all`
- document the portability/performance choice and add a clean-wheel PR smoke check for installed metadata plus Pillow TAR/JPEG/manifest output

## Root cause

The default configuration and Python entrypoints selected TurboJPEG even though PyTurboJPEG was not a core dependency. A normal base installation therefore could not save tile archives.

## Validation

- Python 3.10 packaging metadata test with the `tomli` compatibility path — 1 passed
- Python 3.11 packaging metadata test with stdlib `tomllib` — 1 passed
- `python -m pytest -q` — 400 passed, 3 skipped, 46 deselected
- combined #181 annotation-contract and #175 encoder-focused modules — 214 passed
- explicit Pillow, explicit available TurboJPEG RGB/4:2:0, and mocked missing-TurboJPEG tests — 4 passed
- `python -m build --wheel --no-isolation --skip-dependency-check`
- installed the rebuilt wheel in an isolated environment and ran `scripts/smoke_tile_wheel.py` — verified site-packages import, no TurboJPEG module, Pillow JPEG TAR/manifest, flattened `annotation=None` identity, and installed metadata for both `turbojpeg` and `all`
- two-axis review against authoritative `origin/main`, including the Python 3.10 compatibility retry — no remaining Standards, smell, or Spec findings

Closes #175