### PR TITLE
Make spacing overrides authoritative in every slide reader

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,13 @@ The Python API is the best entrypoint when you want to integrate `hs2p` into you
 - `SlideSpec`
   - Identifies one slide via `sample_id`, `image_path`, and optional `mask_path`
   - `SlideSpec` stays generic because it is shared across tiling and sampling internals
-  - `spacing_at_level_0` can override broken or missing slide metadata
+  - A finite positive `spacing_at_level_0` is the effective level-0 spacing for every
+    backend, including when native metadata is missing. Every effective pyramid spacing
+    is this value multiplied by the backend's level downsample.
+  - If valid native metadata disagrees with the override beyond tight floating-point
+    equivalence, the selected backend emits one warning with the slide path, native
+    value, supplied value, and backend. Missing metadata is rescued without a conflict
+    warning.
 - `TilingConfig`
   - Requested backend, spacing, tile size, overlap, padding, and minimum tissue fraction
 - `SegmentationConfig`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,6 +40,13 @@ slide-2,/data/slide-2.tif,/data/slide-2-tissue-mask.tif,
 ...
 ```
 
+The override must be finite and greater than zero. When supplied, it is authoritative:
+level 0 uses that spacing and every other level uses the override multiplied by the
+selected backend's downsample factor. It can therefore rescue missing spacing metadata.
+If existing native spacing genuinely differs, the selected backend warns once with the
+slide path, native value, supplied value, and backend; floating-point representation
+noise and missing native metadata do not produce a conflict warning.
+
 ## Quick start
 
 Start from [`hs2p/configs/default.yaml`](../hs2p/configs/default.yaml), then edit:

--- a/hs2p/wsi/backends/asap.py
+++ b/hs2p/wsi/backends/asap.py
@@ -5,7 +5,12 @@ from typing import Any
 import cv2
 import numpy as np
 
-from hs2p.wsi.backends.common import paste_region, resolve_padded_read_bounds
+from hs2p.wsi.backends.common import (
+    paste_region,
+    resolve_level0_spacing,
+    resolve_padded_read_bounds,
+)
+from hs2p.wsi.geometry import compute_level_spacings
 
 
 class ASAPReader:
@@ -20,19 +25,29 @@ class ASAPReader:
 
         self._path = Path(path)
         self._wsi = wsd.WholeSlideImage(self._path, backend="asap")
-        self.native_spacing = float(self._wsi.spacings[0])
-        self._spacing = (
-            float(spacing_override)
-            if spacing_override is not None
-            else self.native_spacing
-        )
-        self._spacings = [float(value) for value in self._wsi.spacings]
         self._level_dimensions = [
             (int(width), int(height)) for width, height in self._wsi.shapes
         ]
         self._level_downsamples = [
             (float(value), float(value)) for value in self._wsi.downsamplings
         ]
+        backend_spacings = [float(value) for value in self._wsi.spacings]
+        self.native_spacing = backend_spacings[0] if backend_spacings else None
+        self._spacing = resolve_level0_spacing(
+            path=self._path,
+            backend=self.backend_name,
+            native_spacing=self.native_spacing,
+            spacing_override=spacing_override,
+        )
+        self._spacings = compute_level_spacings(
+            level0_spacing_um=self._spacing,
+            level_downsamples=self._level_downsamples,
+        )
+        self._backend_spacings = (
+            backend_spacings
+            if len(backend_spacings) == len(self._level_dimensions)
+            else self._spacings
+        )
 
     @property
     def backend_name(self) -> str:
@@ -63,7 +78,7 @@ class ASAPReader:
         return list(self._level_downsamples)
 
     def read_level(self, level: int) -> np.ndarray:
-        return np.asarray(self._wsi.get_slide(spacing=self._spacings[level]))
+        return np.asarray(self._wsi.get_slide(spacing=self._backend_spacings[level]))
 
     def read_region(
         self,
@@ -86,7 +101,7 @@ class ASAPReader:
                 int(bounds.read_location[1]),
                 int(read_width),
                 int(read_height),
-                spacing=float(self._spacings[level]),
+                spacing=float(self._backend_spacings[level]),
                 center=False,
             )
         )

--- a/hs2p/wsi/backends/common.py
+++ b/hs2p/wsi/backends/common.py
@@ -1,9 +1,55 @@
 
+import math
+import warnings
 from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 
 WHITE_RGB = 255
+SPACING_EQUIVALENCE_REL_TOL = 1e-12
+
+
+def resolve_level0_spacing(
+    *,
+    path: str | Path,
+    backend: str,
+    native_spacing: float | None,
+    spacing_override: float | None,
+) -> float:
+    """Return the effective level-0 spacing for a concrete reader."""
+    if spacing_override is None:
+        if native_spacing is None:
+            raise ValueError(
+                f"Unable to infer slide spacing for path={path} with backend={backend}. "
+                "Provide spacing_at_level_0 or use a slide with valid spacing metadata."
+            )
+        return float(native_spacing)
+
+    invalid_override_message = (
+        "spacing override must be a finite positive value, "
+        f"got {spacing_override!r}"
+    )
+    try:
+        supplied_spacing = float(spacing_override)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(invalid_override_message) from exc
+    if not math.isfinite(supplied_spacing) or supplied_spacing <= 0:
+        raise ValueError(invalid_override_message)
+    if native_spacing is not None and not math.isclose(
+        float(native_spacing),
+        supplied_spacing,
+        rel_tol=SPACING_EQUIVALENCE_REL_TOL,
+        abs_tol=0.0,
+    ):
+        warnings.warn(
+            "Slide spacing override conflict: "
+            f"path={path}, native={native_spacing}, supplied={supplied_spacing}, "
+            f"backend={backend}; using the supplied level-0 spacing.",
+            UserWarning,
+            stacklevel=2,
+        )
+    return supplied_spacing
 
 
 def make_white_canvas(width: int, height: int) -> np.ndarray:

--- a/hs2p/wsi/backends/cucim.py
+++ b/hs2p/wsi/backends/cucim.py
@@ -6,7 +6,11 @@ from typing import Any, Iterable
 import cv2
 import numpy as np
 
-from hs2p.wsi.backends.common import paste_region, resolve_padded_read_bounds
+from hs2p.wsi.backends.common import (
+    paste_region,
+    resolve_level0_spacing,
+    resolve_padded_read_bounds,
+)
 from hs2p.wsi.geometry import compute_level_spacings
 
 
@@ -58,7 +62,7 @@ def _as_rgb_uint8(region: Any) -> np.ndarray:
     return arr
 
 
-def _extract_spacing_from_metadata(metadata: dict[str, Any]) -> float:
+def _extract_spacing_from_metadata(metadata: dict[str, Any]) -> float | None:
     for entry in metadata.values():
         if not isinstance(entry, dict):
             continue
@@ -92,10 +96,7 @@ def _extract_spacing_from_metadata(metadata: dict[str, Any]) -> float:
         }.get(str(units).lower() if units is not None else "")
         if factor is not None:
             return float(spacing) * factor
-    raise ValueError(
-        "Unable to infer slide spacing from cuCIM metadata. "
-        "Provide spacing_at_level_0 or use a slide with valid spacing metadata."
-    )
+    return None
 
 
 class CuCIMReader:
@@ -146,13 +147,14 @@ class CuCIMReader:
                 for width, height in self._level_dimensions
             ]
         self.native_spacing = _extract_spacing_from_metadata(self._metadata)
-        self._spacing = (
-            float(spacing_override)
-            if spacing_override is not None
-            else self.native_spacing
+        self._spacing = resolve_level0_spacing(
+            path=path,
+            backend=self.backend_name,
+            native_spacing=self.native_spacing,
+            spacing_override=spacing_override,
         )
         self._spacings = compute_level_spacings(
-            level0_spacing_um=self.native_spacing,
+            level0_spacing_um=self._spacing,
             level_downsamples=self._level_downsamples,
         )
 

--- a/hs2p/wsi/backends/openslide.py
+++ b/hs2p/wsi/backends/openslide.py
@@ -4,7 +4,11 @@ from typing import Any
 
 import numpy as np
 
-from hs2p.wsi.backends.common import paste_region, resolve_padded_read_bounds
+from hs2p.wsi.backends.common import (
+    paste_region,
+    resolve_level0_spacing,
+    resolve_padded_read_bounds,
+)
 from hs2p.wsi.geometry import compute_level_spacings
 
 
@@ -20,10 +24,11 @@ class OpenSlideReader:
 
         self._slide = openslide.OpenSlide(str(path))
         self.native_spacing = self._extract_spacing()
-        self._spacing = (
-            float(spacing_override)
-            if spacing_override is not None
-            else self.native_spacing
+        self._spacing = resolve_level0_spacing(
+            path=path,
+            backend=self.backend_name,
+            native_spacing=self.native_spacing,
+            spacing_override=spacing_override,
         )
         self._level_dimensions = [
             (int(width), int(height)) for width, height in self._slide.level_dimensions
@@ -32,11 +37,11 @@ class OpenSlideReader:
             (float(value), float(value)) for value in self._slide.level_downsamples
         ]
         self._spacings = compute_level_spacings(
-            level0_spacing_um=self.native_spacing,
+            level0_spacing_um=self._spacing,
             level_downsamples=self._level_downsamples,
         )
 
-    def _extract_spacing(self) -> float:
+    def _extract_spacing(self) -> float | None:
         properties = self._slide.properties
         mpp_x = properties.get("openslide.mpp-x")
         if mpp_x is not None:
@@ -46,10 +51,7 @@ class OpenSlideReader:
             objective_value = float(objective)
             if objective_value > 0:
                 return 10.0 / objective_value
-        raise ValueError(
-            "Unable to infer slide spacing from OpenSlide metadata. "
-            "Provide spacing_at_level_0 or use a slide with valid spacing metadata."
-        )
+        return None
 
     @property
     def backend_name(self) -> str:

--- a/hs2p/wsi/backends/vips.py
+++ b/hs2p/wsi/backends/vips.py
@@ -4,7 +4,11 @@ from typing import Any
 
 import numpy as np
 
-from hs2p.wsi.backends.common import paste_region, resolve_padded_read_bounds
+from hs2p.wsi.backends.common import (
+    paste_region,
+    resolve_level0_spacing,
+    resolve_padded_read_bounds,
+)
 from hs2p.wsi.geometry import compute_level_spacings
 
 VIPS_SUPPORTED_SUFFIXES = {
@@ -36,6 +40,7 @@ def _vips_to_numpy(image) -> np.ndarray:
         arr = arr[..., :3]
     return arr
 
+
 class VIPSReader:
     def __init__(self, path: str | Path, *, spacing_override: float | None = None):
         try:
@@ -57,17 +62,18 @@ class VIPSReader:
         self._level_dimensions = self._resolve_level_dimensions()
         self._level_downsamples = self._resolve_level_downsamples()
         self.native_spacing = self._extract_spacing()
-        self._spacing = (
-            float(spacing_override)
-            if spacing_override is not None
-            else self.native_spacing
+        self._spacing = resolve_level0_spacing(
+            path=self._path,
+            backend=self.backend_name,
+            native_spacing=self.native_spacing,
+            spacing_override=spacing_override,
         )
         self._spacings = compute_level_spacings(
-            level0_spacing_um=self.native_spacing,
+            level0_spacing_um=self._spacing,
             level_downsamples=self._level_downsamples,
         )
 
-    def _extract_spacing(self) -> float:
+    def _extract_spacing(self) -> float | None:
         fields = set(self._root.get_fields())
         if "openslide.mpp-x" in fields:
             return float(self._root.get("openslide.mpp-x"))
@@ -77,10 +83,7 @@ class VIPSReader:
             xres = float(self._root.get("xres"))
             if xres > 0:
                 return 1000.0 / xres
-        raise ValueError(
-            "Unable to infer slide spacing from libvips metadata. "
-            "Provide spacing_at_level_0 or use a slide with valid spacing metadata."
-        )
+        return None
 
     def _resolve_level_dimensions(self) -> list[tuple[int, int]]:
         levels: list[tuple[int, int]] = []

--- a/tests/test_wsi_reader_protocol.py
+++ b/tests/test_wsi_reader_protocol.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -107,6 +108,115 @@ class SyntheticBatchSlideReader(SyntheticSlideReader):
         return [self.read_region(location, level, size) for location in locations]
 
 
+def _make_concrete_reader(
+    monkeypatch,
+    *,
+    backend: str,
+    native_spacing: float | None,
+    spacing_override: float | None,
+):
+    level_dimensions = [(400, 200), (160, 80), (100, 50)]
+    level_downsamples = [1.0, 2.5, 4.0]
+
+    if backend == "asap":
+        from hs2p.wsi.backends.asap import ASAPReader
+
+        slide = SimpleNamespace(
+            spacings=(
+                [native_spacing * value for value in level_downsamples]
+                if native_spacing is not None
+                else []
+            ),
+            shapes=level_dimensions,
+            downsamplings=level_downsamples,
+        )
+        fake_module = SimpleNamespace(WholeSlideImage=MagicMock(return_value=slide))
+        monkeypatch.setitem(sys.modules, "wholeslidedata", fake_module)
+        return ASAPReader("fake.svs", spacing_override=spacing_override)
+
+    if backend == "cucim":
+        from hs2p.wsi.backends.cucim import CuCIMReader
+        import hs2p.wsi.backends.cucim as cucim_reader_mod
+
+        metadata = {
+            "cucim": {
+                "resolutions": {
+                    "level_dimensions": level_dimensions,
+                    "level_downsamples": level_downsamples,
+                }
+            }
+        }
+        if native_spacing is not None:
+            metadata["openslide"] = {"MPP": native_spacing}
+        slide = SimpleNamespace(metadata=metadata)
+        fake_module = SimpleNamespace(CuImage=MagicMock(return_value=slide))
+        original_import_module = cucim_reader_mod.importlib.import_module
+        monkeypatch.setattr(
+            cucim_reader_mod.importlib,
+            "import_module",
+            lambda name: (
+                fake_module if name == "cucim" else original_import_module(name)
+            ),
+        )
+        return CuCIMReader("fake.svs", spacing_override=spacing_override)
+
+    if backend == "openslide":
+        from hs2p.wsi.backends.openslide import OpenSlideReader
+
+        properties = (
+            {"openslide.mpp-x": str(native_spacing)}
+            if native_spacing is not None
+            else {}
+        )
+        slide = SimpleNamespace(
+            properties=properties,
+            level_dimensions=level_dimensions,
+            level_downsamples=level_downsamples,
+            level_count=len(level_dimensions),
+        )
+        fake_module = SimpleNamespace(OpenSlide=MagicMock(return_value=slide))
+        monkeypatch.setitem(sys.modules, "openslide", fake_module)
+        return OpenSlideReader("fake.svs", spacing_override=spacing_override)
+
+    if backend == "vips":
+        from hs2p.wsi.backends.vips import VIPSReader
+
+        class FakeVIPSImage:
+            def __init__(self, width, height, fields):
+                self.width = width
+                self.height = height
+                self._fields = fields
+
+            def get_fields(self):
+                return list(self._fields)
+
+            def get(self, name):
+                return self._fields[name]
+
+        fields = {
+            "vips-loader": "openslideload",
+            "openslide.level-count": len(level_dimensions),
+        }
+        if native_spacing is not None:
+            fields["openslide.mpp-x"] = native_spacing
+        images = [
+            FakeVIPSImage(width, height, fields)
+            for width, height in level_dimensions
+        ]
+
+        def new_from_file(path, *, level=None, **kwargs):
+            del path, kwargs
+            return images[0 if level is None else int(level)]
+
+        fake_module = SimpleNamespace(
+            Image=SimpleNamespace(new_from_file=new_from_file)
+        )
+        monkeypatch.setitem(sys.modules, "pyvips", fake_module)
+        return VIPSReader("fake.svs", spacing_override=spacing_override)
+
+    raise AssertionError(f"unsupported test backend: {backend}")
+
+
 def test_synthetic_reader_conforms_to_slide_reader_protocol():
     reader = SyntheticSlideReader()
     assert isinstance(reader, SlideReader)
@@ -130,6 +240,93 @@ def test_synthetic_batch_reader_conforms_to_optional_batch_protocol():
     regions = list(reader.read_regions([(0, 0), (16, 16)], 0, (32, 32), num_workers=2))
     assert len(regions) == 2
     assert all(region.shape == (32, 32, 3) for region in regions)
+
+
+@pytest.mark.parametrize("backend", ["asap", "cucim", "openslide", "vips"])
+def test_spacing_override_rescues_missing_metadata_for_every_reader(
+    monkeypatch, recwarn, backend
+):
+    reader = _make_concrete_reader(
+        monkeypatch,
+        backend=backend,
+        native_spacing=None,
+        spacing_override=0.25,
+    )
+
+    assert reader.native_spacing is None
+    assert reader.spacing == 0.25
+    assert reader.spacings == [0.25, 0.625, 1.0]
+    assert len(recwarn) == 0
+
+
+@pytest.mark.parametrize("backend", ["asap", "cucim", "openslide", "vips"])
+def test_native_spacing_remains_baseline_without_override(
+    monkeypatch, recwarn, backend
+):
+    reader = _make_concrete_reader(
+        monkeypatch,
+        backend=backend,
+        native_spacing=0.5,
+        spacing_override=None,
+    )
+
+    assert reader.spacing == 0.5
+    assert reader.spacings == [0.5, 1.25, 2.0]
+    assert len(recwarn) == 0
+
+
+@pytest.mark.parametrize("backend", ["asap", "cucim", "openslide", "vips"])
+@pytest.mark.parametrize(
+    "spacing_override",
+    [0.0, -0.25, float("nan"), float("inf"), float("-inf"), "not-a-spacing"],
+)
+def test_every_reader_rejects_invalid_spacing_overrides(
+    monkeypatch, backend, spacing_override
+):
+    with pytest.raises(ValueError, match="finite positive"):
+        _make_concrete_reader(
+            monkeypatch,
+            backend=backend,
+            native_spacing=0.5,
+            spacing_override=spacing_override,
+        )
+
+
+@pytest.mark.parametrize("backend", ["asap", "cucim", "openslide", "vips"])
+def test_conflicting_override_warns_once_with_reader_context(
+    monkeypatch, recwarn, backend
+):
+    reader = _make_concrete_reader(
+        monkeypatch,
+        backend=backend,
+        native_spacing=0.5,
+        spacing_override=0.25,
+    )
+
+    assert reader.spacing == 0.25
+    assert reader.spacings == [0.25, 0.625, 1.0]
+    assert len(recwarn) == 1
+    message = str(recwarn[0].message)
+    assert "path=fake.svs" in message
+    assert "native=0.5" in message
+    assert "supplied=0.25" in message
+    assert f"backend={backend}" in message
+
+
+@pytest.mark.parametrize("backend", ["asap", "cucim", "openslide", "vips"])
+def test_numerically_equivalent_override_does_not_warn(
+    monkeypatch, recwarn, backend
+):
+    reader = _make_concrete_reader(
+        monkeypatch,
+        backend=backend,
+        native_spacing=0.1 + 0.2,
+        spacing_override=0.3,
+    )
+
+    assert reader.spacing == 0.3
+    assert reader.spacings == [0.3, 0.75, 1.2]
+    assert len(recwarn) == 0
 
 
 def test_select_level_prefers_finer_level_when_closest_match_is_too_coarse():
@@ -163,68 +360,6 @@ def test_cucim_reader_import_guard():
 
     with pytest.raises(ImportError, match="cucim"):
         CuCIMReader("fake.svs")
-
-
-def test_cucim_reader_keeps_metadata_spacing_as_pyramid_baseline(monkeypatch):
-    from hs2p.wsi.backends.cucim import CuCIMReader
-    import hs2p.wsi.backends.cucim as cucim_reader_mod
-
-    mock_cu_image = MagicMock()
-    mock_cu_image.metadata = {
-        "openslide": {"MPP": 0.5},
-        "cucim": {
-            "resolutions": {
-                "level_dimensions": [[400, 200], [200, 100], [100, 50]],
-                "level_downsamples": [1.0, 2.0, 4.0],
-            }
-        },
-    }
-    fake_cucim = type(
-        "FakeCuCIMModule",
-        (),
-        {"CuImage": MagicMock(return_value=mock_cu_image)},
-    )()
-    original_import_module = cucim_reader_mod.importlib.import_module
-    monkeypatch.setattr(
-        cucim_reader_mod.importlib,
-        "import_module",
-        lambda name: fake_cucim if name == "cucim" else original_import_module(name),
-    )
-
-    reader = CuCIMReader("fake.svs", spacing_override=0.25)
-
-    assert reader.native_spacing == 0.5
-    assert reader.spacing == 0.25
-    assert reader.spacings == [0.5, 1.0, 2.0]
-
-
-def test_cucim_reader_override_does_not_rescue_missing_spacing_metadata(monkeypatch):
-    from hs2p.wsi.backends.cucim import CuCIMReader
-    import hs2p.wsi.backends.cucim as cucim_reader_mod
-
-    mock_cu_image = MagicMock()
-    mock_cu_image.metadata = {
-        "cucim": {
-            "resolutions": {
-                "level_dimensions": [[400, 200], [200, 100]],
-                "level_downsamples": [1.0, 2.0],
-            }
-        },
-    }
-    fake_cucim = type(
-        "FakeCuCIMModule",
-        (),
-        {"CuImage": MagicMock(return_value=mock_cu_image)},
-    )()
-    original_import_module = cucim_reader_mod.importlib.import_module
-    monkeypatch.setattr(
-        cucim_reader_mod.importlib,
-        "import_module",
-        lambda name: fake_cucim if name == "cucim" else original_import_module(name),
-    )
-
-    with pytest.raises(ValueError, match="spacing"):
-        CuCIMReader("fake.svs", spacing_override=0.25)
 
 
 def test_cucim_reader_batched_reads_suppress_native_stderr():


### PR DESCRIPTION
## Summary

- make a finite positive level-0 spacing override authoritative in ASAP, cuCIM, OpenSlide, and VIPS readers
- rescue missing native spacing metadata and derive every effective pyramid spacing from the override and backend downsample factors
- emit one contextual warning for genuine native/override conflicts while suppressing floating-point-only differences
- add deterministic reader-protocol regression coverage and document the effective-spacing contract

## Why

Concrete readers previously exposed the override as their level-0 `spacing` while still deriving pyramid spacings from native metadata. They also attempted native-spacing extraction before applying the override, so missing metadata could not be rescued.

## Validation

Rebased onto `main` at `eddb865` after #182 merged, preserving its Pillow encoder defaults.

- `python -m pytest -q tests/test_wsi_reader_protocol.py --no-cov` — 46 passed, 3 skipped
- `python -m pytest -q` — 438 passed, 3 skipped, 46 deselected
- `git diff --check origin/main...HEAD`
- two-axis review against `origin/main`: Spec clean after scope clarification; Standards raised one integration concern deferred to #178

## Deferred review finding

Override-aware `backend="auto"` probes remain owned by dependent issue #178. Issue #174 intentionally implements the concrete-reader contract and does not expand into backend-selection behavior.

Closes #174