### PR TITLE
Report partial batch failures truthfully

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -135,6 +135,14 @@ artifacts = tile_slides(
 )
 ```
 
+`tile_slides()` attempts every requested slide independently. If one or more
+slides fail, it returns the `TilingArtifacts` for successful slides and emits
+one `BatchPartialFailureWarning` after the batch has finished. The warning names
+every failed slide and its reason. Full per-slide errors and tracebacks remain
+available in `output/process_list.csv`.
+
+An all-success batch returns every artifact without emitting this warning.
+
 When `save_mask_preview=True`, `tile_slides()` writes `preview/mask/{sample_id}.jpg`
 as a contour-only slide preview. The outer tissue boundary uses evergreen
 `#255E3B`, while hole contours use coral `#F26B3A`. `tissue_contour_color`

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -144,6 +144,10 @@ When `is_within_tolerance` is true, `tile_size_lv0` and `step_px_lv0` reflect th
 - `error`
 - `traceback`
 
+Each attempted slide is recorded as `success` or `failed`. Failure rows retain
+the concise reason in `error` and the detailed diagnostic traceback in
+`traceback`; they are failed slides, not skipped slides.
+
 ### Sampling manifest
 
 - `sample_id`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -192,6 +192,17 @@ When stdout is non-interactive, `hs2p` falls back to concise plain-text progress
 
 Detailed logs still go to `output_dir/logs/log.txt`.
 
+## Partial batch failures
+
+The CLI attempts every requested slide and persists every outcome to
+`process_list.csv`. If any slide failed, it reports a completed run with failed
+slides and exits non-zero only after the manifest and tracebacks have been
+written. It exits zero when every slide succeeded.
+
+This differs from the Python `tile_slides()` contract: Python callers receive
+the successful artifacts and one aggregate `BatchPartialFailureWarning` instead
+of a non-zero process exit.
+
 ## Resume and precomputed artifacts
 
 - `resume: true` expects the current process-list schema

--- a/hs2p/__init__.py
+++ b/hs2p/__init__.py
@@ -1,4 +1,5 @@
 from hs2p.api import (
+    BatchPartialFailureWarning,
     FilterConfig,
     PreviewConfig,
     SegmentationConfig,

--- a/hs2p/__main__.py
+++ b/hs2p/__main__.py
@@ -1,8 +1,12 @@
 import argparse
+from dataclasses import dataclass
 from pathlib import Path
 
+import pandas as pd
+
 import hs2p.progress as progress
-from hs2p.api import tile_slides
+from hs2p.api import TilingArtifacts, tile_slides
+from hs2p.artifacts import summarize_failed_slides
 from hs2p.configs.loader import DEFAULT_JPEG_BACKEND
 from hs2p.configs.resolvers import (
     resolve_filter_config,
@@ -13,6 +17,12 @@ from hs2p.configs.resolvers import (
     resolve_tiling_config,
 )
 from hs2p.utils import load_csv, setup
+
+
+@dataclass(frozen=True)
+class _CliRunResult:
+    artifacts: list[TilingArtifacts]
+    failed_slide_count: int
 
 
 def get_args_parser(add_help: bool = True):
@@ -123,21 +133,38 @@ def main(args):
                     output_mode=output_mode,
                 )
             artifacts = tile_slides(whole_slides, **tile_kwargs)
+            process_list_path = output_dir / "process_list.csv"
+            try:
+                process_df = pd.read_csv(process_list_path)
+            except pd.errors.EmptyDataError:
+                failed_slide_count = 0
+            else:
+                failed_slide_count = len(
+                    summarize_failed_slides(
+                        process_df.to_dict(orient="records")
+                    )
+                )
             progress.emit_progress(
                 "run.finished",
                 command="tiling",
                 output_dir=str(output_dir),
-                process_list_path=str(output_dir / "process_list.csv"),
+                process_list_path=str(process_list_path),
                 logs_dir=str(output_dir / "logs"),
+                failed_slide_count=failed_slide_count,
             )
-            return artifacts
+            return _CliRunResult(
+                artifacts=artifacts,
+                failed_slide_count=failed_slide_count,
+            )
         except Exception as exc:
             progress.emit_progress("run.failed", stage="tiling", error=str(exc))
             raise
 
 
 def entrypoint(argv=None):
-    main(parse_args(argv))
+    result = main(parse_args(argv))
+    if isinstance(result, _CliRunResult):
+        return int(result.failed_slide_count > 0)
     return 0
 
 

--- a/hs2p/api.py
+++ b/hs2p/api.py
@@ -19,10 +19,16 @@ from hs2p.tiling.tar import (
     _needs_pixel_filtering,
     extract_tiles_to_tar,
 )
-from hs2p.tiling.orchestration import tile_slide, tile_slides, write_tiling_preview
+from hs2p.tiling.orchestration import (
+    BatchPartialFailureWarning,
+    tile_slide,
+    tile_slides,
+    write_tiling_preview,
+)
 from hs2p.wsi import CoordinateOutputMode, CoordinateSelectionStrategy, overlay_mask_on_slide
 
 __all__ = [
+    "BatchPartialFailureWarning",
     "CompatibilitySpec",
     "CoordinateOutputMode",
     "CoordinateSelectionStrategy",

--- a/hs2p/artifacts.py
+++ b/hs2p/artifacts.py
@@ -418,6 +418,29 @@ class ProcessListCheckpoint:
                     temp_path.unlink(missing_ok=True)
 
 
+def summarize_failed_slides(
+    process_rows: Sequence[dict[str, Any]],
+) -> tuple[tuple[str, str], ...]:
+    """Return one ordered ``(sample_id, reason)`` pair per failed slide."""
+    reasons_by_slide: dict[str, list[str]] = {}
+    for row in process_rows:
+        if row.get("tiling_status") != "failed":
+            continue
+        sample_id = str(row["sample_id"])
+        raw_reason = row.get("error")
+        if raw_reason is None or pd.isna(raw_reason):
+            reason = "unknown error"
+        else:
+            reason = str(raw_reason).strip() or "unknown error"
+        reasons = reasons_by_slide.setdefault(sample_id, [])
+        if reason not in reasons:
+            reasons.append(reason)
+    return tuple(
+        (sample_id, " | ".join(reasons))
+        for sample_id, reasons in reasons_by_slide.items()
+    )
+
+
 def load_whole_slides_from_rows(rows: Sequence[dict[str, Any]]) -> list[SlideSpec]:
     whole_slides: list[SlideSpec] = []
     for row in rows:
@@ -451,6 +474,7 @@ __all__ = [
     "load_tiling_result",
     "load_whole_slides_from_rows",
     "save_tiling_result",
+    "summarize_failed_slides",
     "maybe_load_existing_artifacts",
     "optional_path",
     "validate_required_columns",

--- a/hs2p/progress.py
+++ b/hs2p/progress.py
@@ -120,6 +120,13 @@ class TextReporter:
                 f"using {payload['backend']}"
             )
         if kind == "run.finished":
+            failed_slide_count = payload.get("failed_slide_count", 0)
+            if failed_slide_count:
+                noun = "slide" if failed_slide_count == 1 else "slides"
+                return (
+                    f"Run completed with {failed_slide_count} failed {noun}. "
+                    f"Output: {payload['output_dir']}"
+                )
             return f"Run finished successfully. Output: {payload['output_dir']}"
         if kind == "run.failed":
             return f"Run failed during {payload['stage']}: {payload['error']}"
@@ -315,13 +322,17 @@ class RichReporter:
                 )
             return
         if kind == "run.finished":
+            failed_slide_count = payload.get("failed_slide_count", 0)
+            rows = [
+                ("Output", payload["output_dir"]),
+                ("Process list", payload["process_list_path"]),
+                ("Logs", payload["logs_dir"]),
+            ]
+            if failed_slide_count:
+                rows.insert(0, ("Failed slides", str(failed_slide_count)))
             self._print_summary(
-                "Run Complete",
-                [
-                    ("Output", payload["output_dir"]),
-                    ("Process list", payload["process_list_path"]),
-                    ("Logs", payload["logs_dir"]),
-                ],
+                "Run Complete" if not failed_slide_count else "Run Complete with Failures",
+                rows,
             )
             return
         if kind == "run.failed":

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import multiprocessing as mp
 import traceback
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -51,9 +52,29 @@ from hs2p.artifacts import (
     maybe_load_existing_artifacts,
     optional_path,
     save_tiling_result,
+    summarize_failed_slides,
     validate_required_columns,
     validate_tiling_artifacts,
 )
+
+
+class BatchPartialFailureWarning(UserWarning):
+    """A completed batch attempted every slide but one or more slides failed."""
+
+    def __init__(self, failures: Sequence[tuple[str, str]]):
+        self.failures = tuple(failures)
+        failed_slide_count = len(self.failures)
+        noun = "slide" if failed_slide_count == 1 else "slides"
+        details = "; ".join(
+            f"{sample_id}: {reason}" for sample_id, reason in self.failures
+        )
+        super().__init__(
+            f"Batch completed with {failed_slide_count} failed {noun}: {details}"
+        )
+
+
+def _exception_reason(exc: BaseException) -> str:
+    return str(exc).strip() or type(exc).__name__
 
 
 def _resolve_effective_backends(
@@ -779,7 +800,7 @@ def _build_failure_process_row(
         "tiles_tar_path": np.nan,
         "mask_preview_path": np.nan,
         "tiling_preview_path": np.nan,
-        "error": error,
+        "error": error.strip() or "unknown error",
         "traceback": traceback_text,
     }
 
@@ -986,7 +1007,7 @@ def _compute_and_save_tiling_artifacts_from_request(
                 request.tiling.requested_mask_backend if has_mask else None
             ),
             mask_backend=request.tiling.mask_backend if has_mask else None,
-            error=str(exc),
+            error=_exception_reason(exc),
             traceback_text=traceback.format_exc(),
         )
 
@@ -1051,7 +1072,7 @@ def _resolve_mask_for_request(
             backend=effective_tiling.backend,
             requested_mask_backend=requested_mask_backend,
             mask_backend=mask_backend,
-            error=str(exc),
+            error=_exception_reason(exc),
             traceback_text=traceback.format_exc(),
         )
 
@@ -1073,7 +1094,7 @@ def _resolve_mask_for_request_safe(
                 request.tiling.requested_mask_backend if has_mask else None
             ),
             mask_backend=request.tiling.mask_backend if has_mask else None,
-            error=str(exc),
+            error=_exception_reason(exc),
             traceback_text=traceback.format_exc(),
         )
 
@@ -1363,7 +1384,7 @@ def tile_slides(
             planned_work.append(
                 _SlideWork(
                     whole_slide=whole_slide,
-                    error=str(exc),
+                    error=_exception_reason(exc),
                     traceback_text=traceback.format_exc(),
                     requested_backend=tiling.requested_backend,
                     backend=(
@@ -1539,12 +1560,13 @@ def tile_slides(
                 )
             except Exception as exc:
                 emit_progress_log(
-                    f"[tile_slides] FAILED {previous_pending.whole_slide.sample_id}: {exc}",
+                    f"[tile_slides] FAILED {previous_pending.whole_slide.sample_id}: "
+                    f"{_exception_reason(exc)}",
                 )
                 _record_process_row(
                     _build_failure_process_row(
                         whole_slide=previous_pending.whole_slide,
-                        error=str(exc),
+                        error=_exception_reason(exc),
                         traceback_text=traceback.format_exc(),
                         requested_backend=previous_pending.base_artifact.requested_backend,
                         backend=previous_pending.base_artifact.backend,
@@ -1841,10 +1863,14 @@ def tile_slides(
         if preview_executor is not None:
             preview_executor.shutdown(wait=True)
     process_list_checkpoint.flush(process_rows)
+    failures = summarize_failed_slides(process_rows)
+    if failures:
+        warnings.warn(BatchPartialFailureWarning(failures), stacklevel=2)
     return artifacts
 
 
 __all__ = [
+    "BatchPartialFailureWarning",
     "extract_tiles_to_tar",
     "tile_slide",
     "tile_slides",

--- a/hs2p/utils/misc.py
+++ b/hs2p/utils/misc.py
@@ -84,7 +84,7 @@ def load_csv(
     require_mask_column: bool = False,
 ):
     csv_path = Path(cfg.csv).resolve()
-    df = pd.read_csv(csv_path)
+    df = pd.read_csv(csv_path, converters={"sample_id": str})
     required = {"sample_id", "image_path"}
     missing = sorted(required - set(df.columns))
     if missing:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -270,7 +270,7 @@ def test_cli_entrypoint_exits_nonzero_after_partial_failure_manifest_is_persiste
         exit_code = tiling_mod.entrypoint([str(tmp_path / "config.yaml")])
 
     assert attempted[0] == "slide-1"
-    assert pd.isna(attempted[1])
+    assert attempted[1] == "nan"
     assert attempted[2] == "slide-3"
     process_df = pd.read_csv(Path(cfg.output_dir) / "process_list.csv")
     assert process_df["tiling_status"].tolist() == ["success", "failed", "success"]

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 from types import SimpleNamespace
+import warnings
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from hs2p.api import SlideSpec, TilingArtifacts
+from hs2p.api import BatchPartialFailureWarning, SlideSpec, TilingArtifacts
 import hs2p.__main__ as tiling_mod
 
 
@@ -193,3 +195,139 @@ def test_cli_entrypoint_invokes_main(monkeypatch, tmp_path: Path):
     assert exit_code == 0
     assert captured["args"].config_file == str(config_path)
     assert captured["args"].opts == ["output_dir=/tmp/out"]
+
+
+def test_cli_entrypoint_exits_nonzero_after_partial_failure_manifest_is_persisted(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+):
+    csv_path = tmp_path / "slides.csv"
+    csv_path.write_text(
+        "sample_id,image_path,mask_path\n"
+        "slide-1,slide-1.svs,slide-1-mask.png\n"
+        "nan,slide-2.svs,slide-2-mask.png\n"
+        "slide-3,slide-3.svs,slide-3-mask.png\n"
+    )
+    cfg = _base_cfg(tmp_path, csv_path)
+    attempted = []
+
+    monkeypatch.setattr(tiling_mod, "setup", lambda args: cfg)
+
+    def _completed_partial_batch(whole_slides, *, output_dir, **kwargs):
+        del kwargs
+        attempted.extend(slide.sample_id for slide in whole_slides)
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(
+            [
+                {
+                    "sample_id": "slide-1",
+                    "tiling_status": "success",
+                    "error": np.nan,
+                    "traceback": np.nan,
+                },
+                {
+                    "sample_id": "nan",
+                    "tiling_status": "failed",
+                    "error": "damaged header",
+                    "traceback": "Traceback...\nRuntimeError: damaged header",
+                },
+                {
+                    "sample_id": "slide-3",
+                    "tiling_status": "success",
+                    "error": np.nan,
+                    "traceback": np.nan,
+                },
+            ]
+        ).to_csv(output_dir / "process_list.csv", index=False)
+        warnings.warn(
+            BatchPartialFailureWarning([("nan", "damaged header")]),
+            stacklevel=2,
+        )
+        return [
+            TilingArtifacts(
+                sample_id="slide-1",
+                coordinates_npz_path=output_dir / "tiles" / "slide-1.coordinates.npz",
+                coordinates_meta_path=output_dir
+                / "tiles"
+                / "slide-1.coordinates.meta.json",
+                num_tiles=2,
+            ),
+            TilingArtifacts(
+                sample_id="slide-3",
+                coordinates_npz_path=output_dir / "tiles" / "slide-3.coordinates.npz",
+                coordinates_meta_path=output_dir
+                / "tiles"
+                / "slide-3.coordinates.meta.json",
+                num_tiles=2,
+            ),
+        ]
+
+    monkeypatch.setattr(tiling_mod, "tile_slides", _completed_partial_batch)
+
+    with pytest.warns(BatchPartialFailureWarning):
+        exit_code = tiling_mod.entrypoint([str(tmp_path / "config.yaml")])
+
+    assert attempted[0] == "slide-1"
+    assert pd.isna(attempted[1])
+    assert attempted[2] == "slide-3"
+    process_df = pd.read_csv(Path(cfg.output_dir) / "process_list.csv")
+    assert process_df["tiling_status"].tolist() == ["success", "failed", "success"]
+    assert pd.isna(process_df.loc[1, "sample_id"])
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert "Run completed with 1 failed slide." in output
+    assert "successfully" not in output
+
+
+def test_cli_entrypoint_exits_zero_when_every_persisted_slide_succeeded(
+    monkeypatch,
+    capsys,
+    tmp_path: Path,
+):
+    csv_path = _write_csv(tmp_path)
+    cfg = _base_cfg(tmp_path, csv_path)
+
+    monkeypatch.setattr(tiling_mod, "setup", lambda args: cfg)
+
+    def _completed_successful_batch(whole_slides, *, output_dir, **kwargs):
+        del kwargs
+        assert [slide.sample_id for slide in whole_slides] == ["slide-1"]
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(
+            [
+                {
+                    "sample_id": "slide-1",
+                    "tiling_status": "success",
+                    "error": np.nan,
+                    "traceback": np.nan,
+                }
+            ]
+        ).to_csv(output_dir / "process_list.csv", index=False)
+        return [
+            TilingArtifacts(
+                sample_id="slide-1",
+                coordinates_npz_path=output_dir / "tiles" / "slide-1.coordinates.npz",
+                coordinates_meta_path=output_dir
+                / "tiles"
+                / "slide-1.coordinates.meta.json",
+                num_tiles=2,
+            )
+        ]
+
+    monkeypatch.setattr(tiling_mod, "tile_slides", _completed_successful_batch)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        exit_code = tiling_mod.entrypoint([str(tmp_path / "config.yaml")])
+
+    assert exit_code == 0
+    assert not [
+        warning
+        for warning in caught
+        if issubclass(warning.category, BatchPartialFailureWarning)
+    ]
+    output = capsys.readouterr().out
+    assert "Run finished successfully." in output

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -6,11 +6,17 @@ from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import hs2p.api as api_mod
 import hs2p.tiling.orchestration as orchestration_mod
 import hs2p.preprocessing as preprocessing_mod
-from hs2p.api import SlideSpec, TilingArtifacts, tile_slides
+from hs2p.api import (
+    BatchPartialFailureWarning,
+    SlideSpec,
+    TilingArtifacts,
+    tile_slides,
+)
 from hs2p.configs import FilterConfig, SegmentationConfig, TilingConfig
 import hs2p.__main__ as tiling_mod
 
@@ -491,14 +497,15 @@ def test_tile_slides_emits_progress_for_reused_success_and_failure(
     monkeypatch.setattr("hs2p.tiling.orchestration._resolve_mask_for_request", _fake_resolve_mask_for_request)
 
     with progress.activate_progress_reporter(reporter):
-        tile_slides(
-            [slide_a, slide_b, slide_c],
-            tiling=_tiling_config(),
-            segmentation=_segmentation_config(),
-            filtering=_filter_config(),
-            output_dir=run_dir,
-            resume=True,
-        )
+        with pytest.warns(BatchPartialFailureWarning, match="slide-c: boom"):
+            tile_slides(
+                [slide_a, slide_b, slide_c],
+                tiling=_tiling_config(),
+                segmentation=_segmentation_config(),
+                filtering=_filter_config(),
+                output_dir=run_dir,
+                resume=True,
+            )
 
     assert [event.kind for event in reporter.events] == [
         "tissue.started",

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -3309,6 +3309,20 @@ def test_load_csv_rejects_duplicate_sample_id(tmp_path: Path):
         load_csv(cfg)
 
 
+def test_load_csv_preserves_literal_na_like_sample_ids_as_strings(tmp_path: Path):
+    csv_path = tmp_path / "slides.csv"
+    csv_path.write_text(
+        "sample_id,image_path\n"
+        "nan,nan.svs\n"
+        "NA,na.svs\n"
+        "null,null.svs\n"
+    )
+
+    slides = load_csv(SimpleNamespace(csv=str(csv_path)))
+
+    assert [slide.sample_id for slide in slides] == ["nan", "NA", "null"]
+
+
 def test_load_csv_rejects_legacy_mask_columns(tmp_path: Path):
     csv_path = tmp_path / "slides.csv"
     csv_path.write_text(

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -1,6 +1,7 @@
 import json
 import errno
 import tempfile
+import warnings
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +11,7 @@ import pandas as pd
 import pytest
 from omegaconf import OmegaConf
 
+import hs2p
 import hs2p.preprocessing as preprocessing_mod
 from hs2p.api import (
     CompatibilitySpec,
@@ -1451,7 +1453,7 @@ def test_tile_slides_resolves_all_masks_before_computing_any_slide(
     monkeypatch.setattr(
         orchestration_mod,
         "save_tiling_result",
-        lambda result, output_dir, tiles_dir=None: TilingArtifacts(
+        lambda result, output_dir, tiles_dir=None, annotation=None: TilingArtifacts(
             sample_id=result.sample_id,
             coordinates_npz_path=Path(output_dir) / "tiles" / f"{result.sample_id}.coordinates.npz",
             coordinates_meta_path=Path(output_dir) / "tiles" / f"{result.sample_id}.coordinates.meta.json",
@@ -1549,7 +1551,7 @@ def test_tile_slides_emits_tissue_progress_before_tiling_progress(
     monkeypatch.setattr(
         orchestration_mod,
         "save_tiling_result",
-        lambda result, output_dir, tiles_dir=None: TilingArtifacts(
+        lambda result, output_dir, tiles_dir=None, annotation=None: TilingArtifacts(
             sample_id=result.sample_id,
             coordinates_npz_path=Path(output_dir) / "tiles" / f"{result.sample_id}.coordinates.npz",
             coordinates_meta_path=Path(output_dir) / "tiles" / f"{result.sample_id}.coordinates.meta.json",
@@ -2972,14 +2974,15 @@ def test_tile_slides_resume_marks_stale_artifact_as_failed(
         ),
     )
 
-    reused = tile_slides(
-        [SlideSpec(sample_id="slide-6", image_path=Path("requested-slide.svs"))],
-        tiling=tiling_config,
-        segmentation=segmentation_config,
-        filtering=filter_config,
-        output_dir=tmp_path / "run",
-        resume=True,
-    )
+    with pytest.warns(hs2p.BatchPartialFailureWarning, match="slide-6"):
+        reused = tile_slides(
+            [SlideSpec(sample_id="slide-6", image_path=Path("requested-slide.svs"))],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=tmp_path / "run",
+            resume=True,
+        )
 
     assert reused == []
     process_df = pd.read_csv(tmp_path / "run" / "process_list.csv")
@@ -3075,17 +3078,142 @@ def test_tile_slides_logs_failures_in_real_time(
 ):
     _patch_preprocess_slide(monkeypatch, error=RuntimeError("boom"))
 
-    artifacts = tile_slides(
-        [SlideSpec(sample_id="slide-log", image_path=Path("slide-log.svs"))],
-        tiling=tiling_config,
-        segmentation=segmentation_config,
-        filtering=filter_config,
-        output_dir=tmp_path,
-    )
+    with pytest.warns(hs2p.BatchPartialFailureWarning, match="slide-log: boom"):
+        artifacts = tile_slides(
+            [SlideSpec(sample_id="slide-log", image_path=Path("slide-log.svs"))],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=tmp_path,
+        )
 
     assert artifacts == []
     captured = capsys.readouterr()
     assert "[tile_slides] FAILED slide-log: boom" in captured.out
+
+
+def test_tile_slides_returns_successes_and_warns_once_after_attempting_all_slides(
+    monkeypatch,
+    tmp_path: Path,
+    tiling_config: TilingConfig,
+    segmentation_config: SegmentationConfig,
+    filter_config: FilterConfig,
+):
+    attempted = []
+
+    def _result_or_failure(**kwargs):
+        sample_id = kwargs["sample_id"]
+        attempted.append(sample_id)
+        failures = {
+            "slide-2": "damaged header",
+            "slide-3": "permission denied",
+        }
+        if sample_id in failures:
+            raise RuntimeError(failures[sample_id])
+        return _build_preprocessing_result(
+            sample_id=sample_id,
+            image_path=str(kwargs["image_path"]),
+        )
+
+    _patch_preprocess_slide(monkeypatch, result=_result_or_failure)
+
+    with pytest.warns(hs2p.BatchPartialFailureWarning) as caught:
+        artifacts = tile_slides(
+            [
+                SlideSpec(sample_id="slide-1", image_path=Path("slide-1.svs")),
+                SlideSpec(sample_id="slide-2", image_path=Path("slide-2.svs")),
+                SlideSpec(sample_id="slide-3", image_path=Path("slide-3.svs")),
+                SlideSpec(sample_id="slide-4", image_path=Path("slide-4.svs")),
+            ],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=tmp_path,
+            num_workers=1,
+        )
+
+    assert attempted == ["slide-1", "slide-2", "slide-3", "slide-4"]
+    assert [artifact.sample_id for artifact in artifacts] == ["slide-1", "slide-4"]
+    assert len(caught) == 1
+    warning = str(caught[0].message)
+    assert "2 failed slides" in warning
+    assert "slide-2: damaged header" in warning
+    assert "slide-3: permission denied" in warning
+    assert "skipped" not in warning.lower()
+
+    process_df = pd.read_csv(tmp_path / "process_list.csv")
+    failures = process_df[process_df["tiling_status"] == "failed"].set_index("sample_id")
+    assert failures.loc["slide-2", "error"] == "damaged header"
+    assert "RuntimeError: damaged header" in failures.loc["slide-2", "traceback"]
+    assert failures.loc["slide-3", "error"] == "permission denied"
+    assert "RuntimeError: permission denied" in failures.loc["slide-3", "traceback"]
+
+
+def test_tile_slides_all_success_returns_every_artifact_without_partial_failure_warning(
+    monkeypatch,
+    tmp_path: Path,
+    tiling_config: TilingConfig,
+    segmentation_config: SegmentationConfig,
+    filter_config: FilterConfig,
+):
+    def _successful_result(**kwargs):
+        return _build_preprocessing_result(
+            sample_id=kwargs["sample_id"],
+            image_path=str(kwargs["image_path"]),
+        )
+
+    _patch_preprocess_slide(monkeypatch, result=_successful_result)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        artifacts = tile_slides(
+            [
+                SlideSpec(sample_id="slide-1", image_path=Path("slide-1.svs")),
+                SlideSpec(sample_id="slide-2", image_path=Path("slide-2.svs")),
+            ],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=tmp_path,
+            num_workers=1,
+        )
+
+    assert [artifact.sample_id for artifact in artifacts] == ["slide-1", "slide-2"]
+    assert not [
+        warning
+        for warning in caught
+        if issubclass(warning.category, hs2p.BatchPartialFailureWarning)
+    ]
+
+
+def test_tile_slides_partial_failure_warning_supplies_reason_for_blank_exception(
+    monkeypatch,
+    tmp_path: Path,
+    tiling_config: TilingConfig,
+    segmentation_config: SegmentationConfig,
+    filter_config: FilterConfig,
+):
+    monkeypatch.setattr(
+        orchestration_mod,
+        "_resolve_effective_backends",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError()),
+    )
+
+    with pytest.warns(hs2p.BatchPartialFailureWarning) as caught:
+        artifacts = tile_slides(
+            [SlideSpec(sample_id="slide-blank", image_path=Path("slide-blank.svs"))],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=tmp_path,
+        )
+
+    assert artifacts == []
+    assert str(caught[0].message).endswith("slide-blank: RuntimeError")
+    process_df = pd.read_csv(tmp_path / "process_list.csv")
+    assert process_df.loc[0, "error"] == "RuntimeError"
+    assert "RuntimeError" in process_df.loc[0, "traceback"]
+
 
 def test_tile_slides_resume_rejects_unsupported_process_list_schema(
     tmp_path: Path,
@@ -3146,17 +3274,21 @@ def test_tile_slides_writes_process_list_incrementally(
 
     _patch_preprocess_slide(monkeypatch, result=_result_or_crash)
 
-    tile_slides(
-        [
-            SlideSpec(sample_id="slide-1", image_path=Path("slide-1.svs")),
-            SlideSpec(sample_id="slide-2", image_path=Path("slide-2.svs")),
-        ],
-        tiling=tiling_config,
-        segmentation=segmentation_config,
-        filtering=filter_config,
-        output_dir=run_dir,
-        num_workers=1,
-    )
+    with pytest.warns(
+        hs2p.BatchPartialFailureWarning,
+        match="slide-2: simulated mid-run crash",
+    ):
+        tile_slides(
+            [
+                SlideSpec(sample_id="slide-1", image_path=Path("slide-1.svs")),
+                SlideSpec(sample_id="slide-2", image_path=Path("slide-2.svs")),
+            ],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=run_dir,
+            num_workers=1,
+        )
 
     df = pd.read_csv(run_dir / "process_list.csv")
     assert set(df["sample_id"]) == {"slide-1", "slide-2"}
@@ -3759,14 +3891,18 @@ def test_tile_slides_deferred_preview_failure_records_base_artifact_backends(
     monkeypatch.setattr(orchestration_mod, "_write_tiling_preview_from_artifacts", _boom)
     monkeypatch.setattr(orchestration_mod, "write_tiling_preview", _boom)
 
-    artifacts = tile_slides(
-        [SlideSpec(sample_id="slide-preview", image_path=Path("slide-preview.svs"))],
-        tiling=tiling_config,
-        segmentation=segmentation_config,
-        filtering=filter_config,
-        preview=PreviewConfig(save_tiling_preview=True),
-        output_dir=tmp_path,
-    )
+    with pytest.warns(
+        hs2p.BatchPartialFailureWarning,
+        match="slide-preview: preview boom",
+    ):
+        artifacts = tile_slides(
+            [SlideSpec(sample_id="slide-preview", image_path=Path("slide-preview.svs"))],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            preview=PreviewConfig(save_tiling_preview=True),
+            output_dir=tmp_path,
+        )
 
     assert artifacts == []
     df = pd.read_csv(tmp_path / "process_list.csv")
@@ -3820,20 +3956,24 @@ def test_tile_slides_resume_validation_failure_records_requested_and_resolved_ba
 
     monkeypatch.setattr(orchestration_mod, "validate_tiling_artifacts", _reject)
 
-    artifacts = tile_slides(
-        [
-            SlideSpec(
-                sample_id="slide-x",
-                image_path=Path("slide-x.svs"),
-                mask_path=Path("slide-x-mask.tif"),
-            )
-        ],
-        tiling=tiling_config,
-        segmentation=segmentation_config,
-        filtering=filter_config,
-        output_dir=run_dir,
-        resume=True,
-    )
+    with pytest.warns(
+        hs2p.BatchPartialFailureWarning,
+        match="slide-x: backend mismatch",
+    ):
+        artifacts = tile_slides(
+            [
+                SlideSpec(
+                    sample_id="slide-x",
+                    image_path=Path("slide-x.svs"),
+                    mask_path=Path("slide-x-mask.tif"),
+                )
+            ],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=run_dir,
+            resume=True,
+        )
 
     assert artifacts == []
     df = pd.read_csv(run_dir / "process_list.csv")
@@ -3860,19 +4000,23 @@ def test_tile_slides_backend_resolution_failure_records_requested_with_null_reso
 
     monkeypatch.setattr(orchestration_mod, "_resolve_effective_backends", _boom)
 
-    artifacts = tile_slides(
-        [
-            SlideSpec(
-                sample_id="slide-x",
-                image_path=Path("slide-x.svs"),
-                mask_path=Path("slide-x-mask.tif"),
-            )
-        ],
-        tiling=tiling_config,
-        segmentation=segmentation_config,
-        filtering=filter_config,
-        output_dir=tmp_path,
-    )
+    with pytest.warns(
+        hs2p.BatchPartialFailureWarning,
+        match="slide-x: backend probe failed",
+    ):
+        artifacts = tile_slides(
+            [
+                SlideSpec(
+                    sample_id="slide-x",
+                    image_path=Path("slide-x.svs"),
+                    mask_path=Path("slide-x-mask.tif"),
+                )
+            ],
+            tiling=tiling_config,
+            segmentation=segmentation_config,
+            filtering=filter_config,
+            output_dir=tmp_path,
+        )
 
     assert artifacts == []
     df = pd.read_csv(tmp_path / "process_list.csv")


### PR DESCRIPTION
## Summary

- emit one end-of-batch `BatchPartialFailureWarning` from the Python batch API while returning successful artifacts
- derive CLI failure status from the fully persisted process manifest and report a truthful completion summary
- preserve per-slide errors and tracebacks, including actionable exception-type reasons for message-less exceptions
- preserve literal CSV sample IDs such as `nan`, `NA`, and `null` consistently across pandas versions
- document the distinct Python and CLI partial-failure contracts

## Root cause

Per-slide failures were persisted and processing continued, but the completed batch exposed no aggregate Python signal and the CLI always returned zero. Failure-row interpretation was also split across call sites. In addition, `load_csv()` let pandas apply version-dependent NA inference to the identity column before coercion, making literal IDs unstable across supported environments.

## Validation

- retry regression (loader + public CLI): passed
- focused loader/CLI/tiling tests: `88 passed`
- full default suite: `444 passed, 3 skipped, 46 deselected`
- retry Standards review: 0 findings
- retry Spec review: 0 findings
- `git diff --check origin/main...HEAD`: clean

Closes #171