### PR TITLE
Materialize outputs from reused coordinates

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -143,6 +143,12 @@ available in `output/process_list.csv`.
 
 An all-success batch returns every artifact without emitting this warning.
 
+Pass `read_coordinates_from=Path("saved/tiles")` to reuse compatible
+`{sample_id}.coordinates.*` files without recomputing coordinates. This does not mark the
+slide as already processed: `save_tiles=True` still writes the TAR and its manifest sidecar,
+and `PreviewConfig(save_tiling_preview=True)` still renders a preview for non-empty
+coordinates. Outputs that are not enabled are not created.
+
 When `save_mask_preview=True`, `tile_slides()` writes `preview/mask/{sample_id}.jpg`
 as a contour-only slide preview. The outer tissue boundary uses evergreen
 `#255E3B`, while hole contours use coral `#F26B3A`. `tissue_contour_color`

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -20,6 +20,9 @@ Optional tile tar export writes:
 - `{sample_id}.tiles.tar`
 - `{sample_id}.tiles.manifest.csv`
 
+The manifest is the TAR's deterministic sidecar. The returned artifact and process-list row
+record `tiles_tar_path`; the manifest uses the same stem with `.manifest.csv`.
+
 ## `.coordinates.npz`
 
 The NPZ contains the canonical geometry arrays:
@@ -164,6 +167,10 @@ the concise reason in `error` and the detailed diagnostic traceback in
 - `traceback`
 
 ## Resume and validation
+
+`resume` treats a compatible successful process-list row as completed processing. In contrast,
+`read_coordinates_from` reuses coordinate computation only, so downstream TAR and tiling
+preview outputs enabled for the current invocation are still materialized.
 
 Existing artifacts are validated against their structured metadata:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,7 +126,13 @@ backend fields/columns) are rejected clearly rather than loaded.
 ## Config areas
 
 - `tiling.read_coordinates_from`
-  - Reuse precomputed `{sample_id}.coordinates.*` artifacts
+  - Reuse precomputed `{sample_id}.coordinates.*` artifacts instead of recomputing tile
+    coordinates
+  - Coordinate reuse is not completed-slide processing: outputs requested by the current run
+    are still materialized. In particular, `save_tiles: true` writes the tile TAR and manifest,
+    and an enabled tiling preview is rendered when at least one coordinate is present.
+  - Disabled outputs are not created, and a reused zero-tile artifact does not create or report
+    a tiling preview.
 - `tiling.params`
   - spacing, tile size, overlap, tolerance, padding, and minimum tissue fraction
 - `tiling.seg_params`
@@ -205,9 +211,11 @@ of a non-zero process exit.
 
 ## Resume and precomputed artifacts
 
-- `resume: true` expects the current process-list schema
+- `resume: true` treats a compatible successful `process_list.csv` row as completed slide
+  processing and expects the current process-list schema
 - reused artifacts are validated against structured metadata, not `config_hash`
-- `tiling.read_coordinates_from` is the supported way to reuse precomputed coordinate artifacts
+- `tiling.read_coordinates_from` reuses only compatible tile coordinates; downstream outputs
+  enabled for the current run are still produced
 
 ## Performance notes
 

--- a/hs2p/configs/default.yaml
+++ b/hs2p/configs/default.yaml
@@ -9,7 +9,7 @@ save_tiles: false # save extracted tiles as {sample_id}.tiles.tar in addition to
 seed: 0 # seed for reproducibility
 
 tiling:
-  read_coordinates_from: # path to a directory containing {sample_id}.coordinates.npz and {sample_id}.coordinates.meta.json (leave empty to compute tiles)
+  read_coordinates_from: # path to reusable {sample_id}.coordinates.* artifacts; skips coordinate computation only, while requested TAR/preview outputs still run
   backend: "auto" # backend to use for slide reading; auto prefers CuCIM when supported and falls back to ASAP/openslide
   mask_backend: "auto" # backend to use for reading source masks; resolved independently from the mask path (auto uses the same openability-only probe as the slide backend)
   independent_sampling: false # whether to tile each annotation independently (true) or jointly over the union mask (false)

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -565,6 +565,7 @@ class _PendingPreview:
 class _SlideWork:
     whole_slide: SlideSpec
     artifact: TilingArtifacts | None = None
+    reused_coordinates: bool = False
     compute_request: Any | None = None
     error: str | None = None
     traceback_text: str | None = None
@@ -1012,6 +1013,56 @@ def _compute_and_save_tiling_artifacts_from_request(
         )
 
 
+def _materialize_outputs_from_reused_coordinates(
+    *,
+    input_index: int,
+    whole_slide: SlideSpec,
+    artifact: TilingArtifacts,
+    output_dir: Path,
+    save_tiles: bool,
+    jpeg_backend: str,
+    num_workers: int,
+    gpu_decode: bool,
+) -> _ComputeResponse:
+    try:
+        result = load_tiling_result(
+            artifact.coordinates_npz_path,
+            artifact.coordinates_meta_path,
+        )
+        tiles_tar_path = None
+        if save_tiles:
+            tiles_tar_path, result = extract_tiles_to_tar(
+                result,
+                output_dir=output_dir,
+                jpeg_backend=jpeg_backend,
+                num_workers=num_workers,
+                gpu_decode=gpu_decode,
+            )
+        return _ComputeResponse(
+            input_index=input_index,
+            whole_slide=whole_slide,
+            ok=True,
+            artifact=replace(artifact, tiles_tar_path=tiles_tar_path),
+            result=result,
+            requested_backend=artifact.requested_backend,
+            backend=artifact.backend,
+            requested_mask_backend=artifact.requested_mask_backend,
+            mask_backend=artifact.mask_backend,
+        )
+    except Exception as exc:
+        return _ComputeResponse(
+            input_index=input_index,
+            whole_slide=whole_slide,
+            ok=False,
+            requested_backend=artifact.requested_backend,
+            backend=artifact.backend,
+            requested_mask_backend=artifact.requested_mask_backend,
+            mask_backend=artifact.mask_backend,
+            error=_exception_reason(exc),
+            traceback_text=traceback.format_exc(),
+        )
+
+
 def _resolve_mask_for_request(
     request: _MaskResolutionRequest,
 ) -> _MaskResolutionResponse:
@@ -1308,6 +1359,7 @@ def tile_slides(
                 )
             compatibility = compatibility_specs[key]
             artifact: TilingArtifacts | None = None
+            reused_coordinates = False
             if whole_slide.sample_id in existing_successes:
                 row = existing_successes[whole_slide.sample_id]
                 npz_path = optional_path(row["coordinates_npz_path"])
@@ -1329,11 +1381,13 @@ def tile_slides(
                     read_coordinates_from=Path(read_coordinates_from),
                     compatibility=compatibility,
                 )
+                reused_coordinates = artifact is not None
             if artifact is not None:
                 planned_work.append(
                     _SlideWork(
                         whole_slide=whole_slide,
                         artifact=artifact,
+                        reused_coordinates=reused_coordinates,
                     )
                 )
                 continue
@@ -1725,8 +1779,29 @@ def tile_slides(
                 buffered_responses[response.input_index] = response
             return buffered_responses.pop(input_index)
 
-        for planned in planned_work:
+        for input_index, planned in enumerate(planned_work):
             if planned.artifact is not None:
+                if planned.reused_coordinates and (
+                    save_tiles
+                    or (
+                        preview is not None
+                        and preview.save_tiling_preview
+                        and planned.artifact.num_tiles > 0
+                    )
+                ):
+                    _process_compute_response(
+                        _materialize_outputs_from_reused_coordinates(
+                            input_index=input_index,
+                            whole_slide=planned.whole_slide,
+                            artifact=planned.artifact,
+                            output_dir=output_dir,
+                            save_tiles=save_tiles,
+                            jpeg_backend=str(jpeg_backend),
+                            num_workers=num_workers,
+                            gpu_decode=gpu_decode,
+                        )
+                    )
+                    continue
                 artifacts.append(planned.artifact)
                 _record_tiling_success(num_tiles=planned.artifact.num_tiles)
                 _record_process_row(

--- a/tests/test_coordinate_reuse_outputs.py
+++ b/tests/test_coordinate_reuse_outputs.py
@@ -1,0 +1,298 @@
+import csv
+import tarfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from PIL import Image
+
+import hs2p
+import hs2p.preprocessing as preprocessing
+import hs2p.tiling.orchestration as orchestration
+import hs2p.wsi.streaming.stream as stream
+import hs2p.wsi.wsi as wsi
+from fake_wsi_backend import FakeReaderFactory, make_mask_spec, make_slide_spec
+from hs2p.api import (
+    FilterConfig,
+    PreviewConfig,
+    SegmentationConfig,
+    SlideSpec,
+    TilingConfig,
+    save_tiling_result,
+    tile_slides,
+)
+
+
+def _saved_coordinates(
+    tmp_path: Path,
+    *,
+    coords: list[tuple[int, int]],
+) -> tuple[SlideSpec, Path]:
+    slide = SlideSpec(sample_id="reuse-slide", image_path=Path("reuse-slide.svs"))
+    coordinates = np.asarray(coords, dtype=np.int64).reshape((-1, 2))
+    result = preprocessing.TilingResult(
+        tiles=preprocessing.TileGeometry(
+            x=coordinates[:, 0],
+            y=coordinates[:, 1],
+            tissue_fractions=np.full(len(coordinates), 1.0, dtype=np.float32),
+            tile_index=np.arange(len(coordinates), dtype=np.int32),
+            requested_tile_size_px=16,
+            requested_spacing_um=1.0,
+            read_level=0,
+            read_tile_size_px=16,
+            read_spacing_um=1.0,
+            tile_size_lv0=16,
+            is_within_tolerance=True,
+            base_spacing_um=1.0,
+            slide_dimensions=[32, 32],
+            level_downsamples=[1.0, 2.0],
+            overlap=0.0,
+            min_tissue_fraction=0.5,
+        ),
+        sample_id=slide.sample_id,
+        image_path=slide.image_path,
+        backend="asap",
+        requested_backend="asap",
+        tolerance=0.05,
+        step_px_lv0=16,
+        tissue_method="hsv",
+        requested_seg_downsample=64,
+        seg_downsample=64,
+        seg_level=0,
+        seg_spacing_um=1.0,
+        seg_sthresh=8,
+        seg_sthresh_up=255,
+        seg_mthresh=7,
+        seg_close=4,
+        ref_tile_size_px=16,
+        a_t=4,
+        a_h=0,
+        filter_white=False,
+        filter_black=False,
+        white_threshold=220,
+        black_threshold=25,
+        fraction_threshold=0.9,
+    )
+    artifact = save_tiling_result(result, output_dir=tmp_path / "saved")
+    return slide, artifact.coordinates_meta_path.parent
+
+
+def _tiling_config() -> TilingConfig:
+    return TilingConfig(
+        requested_spacing_um=1.0,
+        requested_tile_size_px=16,
+        tolerance=0.05,
+        overlap=0.0,
+        min_coverage={"tissue": 0.5},
+        backend="asap",
+    )
+
+
+def _segmentation_config() -> SegmentationConfig:
+    return SegmentationConfig(
+        method="hsv",
+        downsample=64,
+        sthresh=8,
+        sthresh_up=255,
+        mthresh=7,
+        close=4,
+    )
+
+
+def _filter_config() -> FilterConfig:
+    return FilterConfig(
+        ref_tile_size=16,
+        a_t=4,
+        a_h=0,
+        filter_white=False,
+        filter_black=False,
+        white_threshold=220,
+        black_threshold=25,
+        fraction_threshold=0.9,
+    )
+
+
+def _install_fake_slide_reader(monkeypatch) -> None:
+    factory = FakeReaderFactory(
+        slide_spec=make_slide_spec(),
+        mask_spec=make_mask_spec(np.zeros((32, 32, 1), dtype=np.uint8)),
+    )
+    monkeypatch.setattr(stream, "open_slide", factory)
+    monkeypatch.setattr(wsi, "open_slide", factory)
+
+
+def test_reused_coordinates_materialize_requested_tar_manifest_and_preview(
+    monkeypatch,
+    tmp_path: Path,
+):
+    slide, coordinates_dir = _saved_coordinates(
+        tmp_path,
+        coords=[(0, 0), (16, 0)],
+    )
+    _install_fake_slide_reader(monkeypatch)
+    monkeypatch.setattr(
+        orchestration,
+        "_compute_tiling_result",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("coordinate computation must be skipped")
+        ),
+    )
+
+    output_dir = tmp_path / "run"
+    artifacts = tile_slides(
+        [slide],
+        tiling=_tiling_config(),
+        segmentation=_segmentation_config(),
+        filtering=_filter_config(),
+        preview=PreviewConfig(save_tiling_preview=True, downsample=2),
+        output_dir=output_dir,
+        read_coordinates_from=coordinates_dir,
+        save_tiles=True,
+        jpeg_backend="pil",
+    )
+
+    artifact = artifacts[0]
+    expected_tar = output_dir / "tiles" / "reuse-slide.tiles.tar"
+    expected_manifest = output_dir / "tiles" / "reuse-slide.tiles.manifest.csv"
+    expected_preview = output_dir / "preview" / "tiling" / "reuse-slide.jpg"
+    assert artifact.coordinates_npz_path == coordinates_dir / "reuse-slide.coordinates.npz"
+    assert artifact.coordinates_meta_path == coordinates_dir / "reuse-slide.coordinates.meta.json"
+    assert artifact.tiles_tar_path == expected_tar
+    assert artifact.tiling_preview_path == expected_preview
+
+    with tarfile.open(expected_tar) as archive:
+        assert archive.getnames() == ["000000.jpg", "000001.jpg"]
+    with expected_manifest.open(newline="") as handle:
+        assert list(csv.DictReader(handle)) == [
+            {"tile_index": "0", "x": "0", "y": "0"},
+            {"tile_index": "1", "x": "16", "y": "0"},
+        ]
+    assert Image.open(expected_preview).size == (16, 16)
+
+    row = pd.read_csv(output_dir / "process_list.csv").iloc[0]
+    assert Path(row["coordinates_npz_path"]) == artifact.coordinates_npz_path
+    assert Path(row["coordinates_meta_path"]) == artifact.coordinates_meta_path
+    assert Path(row["tiles_tar_path"]) == expected_tar
+    assert Path(row["tiling_preview_path"]) == expected_preview
+
+
+def test_reused_zero_tile_coordinates_do_not_fabricate_a_preview(
+    monkeypatch,
+    tmp_path: Path,
+):
+    slide, coordinates_dir = _saved_coordinates(tmp_path, coords=[])
+    monkeypatch.setattr(
+        orchestration,
+        "_compute_tiling_result",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("coordinate computation must be skipped")
+        ),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "write_coordinate_preview",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("zero-tile preview rendering must be skipped")
+        ),
+    )
+
+    output_dir = tmp_path / "run"
+    artifacts = tile_slides(
+        [slide],
+        tiling=_tiling_config(),
+        segmentation=_segmentation_config(),
+        filtering=_filter_config(),
+        preview=PreviewConfig(save_tiling_preview=True, downsample=2),
+        output_dir=output_dir,
+        read_coordinates_from=coordinates_dir,
+    )
+
+    assert artifacts[0].num_tiles == 0
+    assert artifacts[0].coordinates_npz_path is None
+    assert artifacts[0].tiling_preview_path is None
+    assert not (output_dir / "preview" / "tiling" / "reuse-slide.jpg").exists()
+    row = pd.read_csv(output_dir / "process_list.csv").iloc[0]
+    assert pd.isna(row["coordinates_npz_path"])
+    assert pd.isna(row["tiling_preview_path"])
+
+
+def test_reused_coordinates_do_not_materialize_disabled_outputs(
+    monkeypatch,
+    tmp_path: Path,
+):
+    slide, coordinates_dir = _saved_coordinates(tmp_path, coords=[(0, 0)])
+    monkeypatch.setattr(
+        orchestration,
+        "_compute_tiling_result",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("coordinate computation must be skipped")
+        ),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "extract_tiles_to_tar",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("disabled tile saving must be skipped")
+        ),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "write_coordinate_preview",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("disabled preview rendering must be skipped")
+        ),
+    )
+
+    output_dir = tmp_path / "run"
+    artifacts = tile_slides(
+        [slide],
+        tiling=_tiling_config(),
+        segmentation=_segmentation_config(),
+        filtering=_filter_config(),
+        output_dir=output_dir,
+        read_coordinates_from=coordinates_dir,
+    )
+
+    assert artifacts[0].tiles_tar_path is None
+    assert artifacts[0].tiling_preview_path is None
+    assert not (output_dir / "tiles" / "reuse-slide.tiles.tar").exists()
+    assert not (output_dir / "tiles" / "reuse-slide.tiles.manifest.csv").exists()
+    assert not (output_dir / "preview" / "tiling" / "reuse-slide.jpg").exists()
+    row = pd.read_csv(output_dir / "process_list.csv").iloc[0]
+    assert pd.isna(row["tiles_tar_path"])
+    assert pd.isna(row["tiling_preview_path"])
+
+
+def test_reused_output_failure_preserves_batch_failure_contract(
+    monkeypatch,
+    tmp_path: Path,
+):
+    slide, coordinates_dir = _saved_coordinates(tmp_path, coords=[(0, 0)])
+    monkeypatch.setattr(
+        orchestration,
+        "extract_tiles_to_tar",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError()),
+    )
+
+    output_dir = tmp_path / "run"
+    with pytest.warns(
+        hs2p.BatchPartialFailureWarning,
+        match="reuse-slide: RuntimeError",
+    ):
+        artifacts = tile_slides(
+            [slide],
+            tiling=_tiling_config(),
+            segmentation=_segmentation_config(),
+            filtering=_filter_config(),
+            output_dir=output_dir,
+            read_coordinates_from=coordinates_dir,
+            save_tiles=True,
+            jpeg_backend="pil",
+        )
+
+    assert artifacts == []
+    row = pd.read_csv(output_dir / "process_list.csv").iloc[0]
+    assert row["tiling_status"] == "failed"
+    assert row["error"] == "RuntimeError"
+    assert "RuntimeError" in row["traceback"]


### PR DESCRIPTION
## Summary

- treat `read_coordinates_from` as coordinate reuse rather than completed slide processing
- materialize requested tile TAR/manifest outputs through the configured JPEG backend
- render requested tiling previews for reused non-empty coordinates while preserving the zero-tile guard
- keep disabled downstream outputs absent and preserve newly produced paths in returned artifacts and `process_list.csv`
- document the distinction between coordinate reuse and `resume`

## Root cause

Compatible coordinate artifacts and successful resume artifacts shared the same terminal planning branch, so reused coordinates bypassed TAR extraction and tiling-preview scheduling.

## Validation

- rebased onto `origin/main` at `954b6c4` after #184 merged
- focused #171/#176/API/CLI/progress tests: `102 passed`
- full suite: `448 passed, 3 skipped, 46 deselected`
- `git diff origin/main...HEAD --check`: clean
- original two-axis review: Standards findings fixed and re-reviewed; Spec review found no issues
- post-conflict affected-axis review: no findings; #171/#184 batch-failure contracts and #176 reuse materialization are both preserved

Closes #176
