### PR TITLE
Preserve recorded output provenance on resume

### DIFF
--- a/.tasks/issue-177.md
+++ b/.tasks/issue-177.md
@@ -8,4 +8,4 @@
 - [x] Run the focused regression test and full test suite.
 - [x] Rebase onto `origin/main` and re-run tests.
 - [x] Run the two-axis `/code-review origin/main` against issue #177, fix findings, and re-green.
-- [ ] Commit, push, and open a draft PR containing `Closes #177`.
+- [x] Commit, push, and open a draft PR containing `Closes #177`.

--- a/.tasks/issue-177.md
+++ b/.tasks/issue-177.md
@@ -1,0 +1,11 @@
+# Issue #177 — Preserve recorded output provenance on resume
+
+- [x] Confirm the public seam: `hs2p.api.tile_slides`.
+- [x] Trace successful-resume artifact reconstruction and process-list rewriting.
+- [x] Red: add a public batch API regression test for preserved deleted TAR/preview paths, untouched downstream outputs, unrelated metadata, and coordinate validation.
+- [x] Green: preserve recorded downstream provenance without filesystem validation or regeneration.
+- [x] Document that downstream files are user-managed after successful completion.
+- [x] Run the focused regression test and full test suite.
+- [x] Rebase onto `origin/main` and re-run tests.
+- [x] Run the two-axis `/code-review origin/main` against issue #177, fix findings, and re-green.
+- [ ] Commit, push, and open a draft PR containing `Closes #177`.

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -189,3 +189,9 @@ reopen a slide, mask, SAM2 checkpoint, or SAM2 model config solely to detect an 
 replacement at the same path. Keeping the contents behind those paths stable is the user's
 responsibility. After replacing a source in place, remove the reusable coordinate artifact or
 write the replacement under a new path so incompatible coordinates are not reused.
+
+After a slide is recorded as successfully completed, resume also treats its downstream
+`tiles_tar_path`, `mask_preview_path`, and `tiling_preview_path` values as provenance. It does
+not check, reopen, regenerate, or repair those files, even when the resumed invocation requests
+the corresponding outputs. Deleting or replacing a recorded downstream file after successful
+completion is the user's responsibility.

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -645,6 +645,7 @@ class _MaskResolutionResponse:
 def _build_success_artifact(
     *,
     base_artifact: TilingArtifacts,
+    tiles_tar_path: Path | None = None,
     mask_preview_path: Path | None,
     tiling_preview_path: Path | None,
 ) -> TilingArtifacts:
@@ -653,7 +654,11 @@ def _build_success_artifact(
         coordinates_npz_path=base_artifact.coordinates_npz_path,
         coordinates_meta_path=base_artifact.coordinates_meta_path,
         num_tiles=base_artifact.num_tiles,
-        tiles_tar_path=base_artifact.tiles_tar_path,
+        tiles_tar_path=(
+            tiles_tar_path
+            if tiles_tar_path is not None
+            else base_artifact.tiles_tar_path
+        ),
         mask_preview_path=mask_preview_path,
         tiling_preview_path=tiling_preview_path,
         backend=base_artifact.backend,
@@ -704,13 +709,6 @@ def _build_success_process_row(
         "error": np.nan,
         "traceback": np.nan,
     }
-
-
-def _existing_file_path(value: Any) -> Path | None:
-    path = optional_path(value)
-    if path is None or not path.is_file():
-        return None
-    return path
 
 
 def _same_optional_path(left: Any, right: Any) -> bool:
@@ -765,7 +763,7 @@ def _merge_existing_resume_metadata(
     for key in ("mask_preview_path", "tiling_preview_path"):
         if key not in existing_row:
             continue
-        existing_path = _existing_file_path(existing_row.get(key))
+        existing_path = optional_path(existing_row.get(key))
         if existing_path is not None and optional_path(merged.get(key)) is None:
             merged[key] = str(existing_path)
     return merged
@@ -1372,8 +1370,9 @@ def tile_slides(
                 )
                 artifact = _build_success_artifact(
                     base_artifact=artifact,
-                    mask_preview_path=_existing_file_path(row.get("mask_preview_path")),
-                    tiling_preview_path=_existing_file_path(row.get("tiling_preview_path")),
+                    tiles_tar_path=optional_path(row.get("tiles_tar_path")),
+                    mask_preview_path=optional_path(row.get("mask_preview_path")),
+                    tiling_preview_path=optional_path(row.get("tiling_preview_path")),
                 )
             if read_coordinates_from is not None and artifact is None:
                 artifact = maybe_load_existing_artifacts(

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -3068,6 +3068,87 @@ def test_tile_slides_resume_preserves_extra_columns_and_existing_preview_paths(
     assert Path(row["tiling_preview_path"]) == tiling_preview_path
 
 
+@pytest.mark.parametrize("request_downstream_outputs", [False, True])
+def test_tile_slides_resume_trusts_recorded_downstream_output_provenance(
+    tmp_path: Path,
+    tiling_config: TilingConfig,
+    segmentation_config: SegmentationConfig,
+    filter_config: FilterConfig,
+    request_downstream_outputs: bool,
+):
+    """A compatible recorded success remains authoritative after its downstream files are
+    deleted, regardless of whether the resumed invocation requests those outputs."""
+    run_dir = tmp_path / "run"
+    result = _build_preprocessing_result(
+        sample_id="slide-resume",
+        image_path="slide-resume.svs",
+    )
+    coordinate_artifacts = save_tiling_result(result, output_dir=run_dir)
+    recorded_paths = {
+        "tiles_tar_path": run_dir / "tiles" / "slide-resume.tar",
+        "mask_preview_path": run_dir / "preview" / "mask" / "slide-resume.jpg",
+        "tiling_preview_path": run_dir / "preview" / "tiling" / "slide-resume.jpg",
+    }
+    for path in recorded_paths.values():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"recorded output")
+        path.unlink()
+
+    pd.DataFrame(
+        [
+            {
+                "sample_id": "slide-resume",
+                "annotation": "tissue",
+                "image_path": "slide-resume.svs",
+                "mask_path": np.nan,
+                "requested_backend": "asap",
+                "backend": "asap",
+                "requested_mask_backend": np.nan,
+                "mask_backend": np.nan,
+                "tiling_status": "success",
+                "num_tiles": coordinate_artifacts.num_tiles,
+                "coordinates_npz_path": str(coordinate_artifacts.coordinates_npz_path),
+                "coordinates_meta_path": str(coordinate_artifacts.coordinates_meta_path),
+                **{key: str(path) for key, path in recorded_paths.items()},
+                "feature_status": "success",
+                "feature_path": "tile_embeddings/slide-resume.npz",
+                "error": np.nan,
+                "traceback": np.nan,
+            }
+        ]
+    ).to_csv(run_dir / "process_list.csv", index=False)
+
+    reused = tile_slides(
+        [SlideSpec(sample_id="slide-resume", image_path=Path("slide-resume.svs"))],
+        tiling=tiling_config,
+        segmentation=segmentation_config,
+        filtering=filter_config,
+        preview=(
+            PreviewConfig(save_mask_preview=True, save_tiling_preview=True)
+            if request_downstream_outputs
+            else None
+        ),
+        output_dir=run_dir,
+        resume=True,
+        save_tiles=request_downstream_outputs,
+    )
+
+    assert len(reused) == 1
+    artifact = reused[0]
+    assert artifact.tiles_tar_path == recorded_paths["tiles_tar_path"]
+    assert artifact.mask_preview_path == recorded_paths["mask_preview_path"]
+    assert artifact.tiling_preview_path == recorded_paths["tiling_preview_path"]
+    assert all(not path.exists() for path in recorded_paths.values())
+
+    row = pd.read_csv(run_dir / "process_list.csv").to_dict(orient="records")[0]
+    assert row["feature_status"] == "success"
+    assert row["feature_path"] == "tile_embeddings/slide-resume.npz"
+    assert {
+        key: Path(row[key])
+        for key in recorded_paths
+    } == recorded_paths
+
+
 def test_tile_slides_logs_failures_in_real_time(
     monkeypatch,
     capsys,


### PR DESCRIPTION
## Summary

- preserve recorded TAR, mask-preview, and tiling-preview paths when reusing a compatible successful slide
- keep unrelated `process_list.csv` metadata and recorded paths even when downstream files were deleted or the resumed invocation does not request them
- document that deleting or replacing downstream files after recorded success is the user's responsibility

## Root cause

Successful resume reconstruction filtered preview paths through filesystem existence checks and did not restore the recorded TAR path. That discarded provenance and caused the metadata merge guard to reject the prior row when it contained a TAR path.

Resume now validates coordinate compatibility as before, then treats recorded downstream paths strictly as provenance. It does not check, reopen, regenerate, or self-heal those files.

## Validation

- rebased onto `main` at `33b4d11` after #185 merged; range-diff confirms both PR commits are patch-identical
- focused #171/#176/#177 combined contract gate: 12 passed
- full suite: 450 passed, 3 skipped, 46 deselected
- `git diff --check origin/main...HEAD`: clean
- two-axis code review: no hard standards violations and no spec findings; one naming smell fixed and re-greened

Closes #177