### PR TITLE
Apply shared automatic backend selection policy

### DIFF
--- a/.tasks/issue-178.md
+++ b/.tasks/issue-178.md
@@ -1,0 +1,32 @@
+# Issue 178: shared automatic backend policy
+
+## Scope
+
+- [x] Resolve slide and mask sources independently with the shared automatic order
+      `cucim -> vips -> openslide -> asap`.
+- [x] Keep explicit backend choices authoritative and preserve requested/resolved provenance.
+- [x] Pass the level-0 spacing override into slide probes, suppress only probe-time spacing
+      discrepancy warnings, and let the selected reader emit the contextual warning.
+- [x] Keep selection openability-only, with no decoded-label inspection or decode retry.
+- [x] Update documentation and release notes, including the artifact-recomputation impact.
+
+## Pre-agreed public seams
+
+The issue acceptance criteria define these behavior seams:
+
+- `resolve_backend(...)`: deterministic automatic fallback and explicit-backend authority.
+- `resolve_backends(...)`: independent role resolution and requested/resolved provenance.
+- `open_slide(..., backend="auto", spacing_override=...)`: spacing metadata rescue in default
+  automatic mode and a single selected-reader warning.
+- High-level tiling backend resolution: propagation of `SlideSpec.spacing_at_level_0`.
+
+## TDD / verification
+
+- [x] Red: add one deterministic failing example for each missing behavior.
+- [x] Green: implement the minimum shared policy needed by each example.
+- [x] Refactor: remove duplicate selection logic and keep compatibility where practical.
+- [x] Run targeted backend-selection tests.
+- [x] Run the full test suite.
+- [x] Rebase onto current `origin/main` and re-run tests.
+- [x] Run Standards and Spec reviews against `origin/main`; fix and re-green.
+- [ ] Commit, push `agent/issue-178`, and open a draft PR with `Closes #178`.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The supported backend set is:
 - `asap`
 
 `auto` prefers `cucim -> vips -> openslide -> asap`.
+Slide and source-mask paths follow this order independently, using openability only.
+Because the priority changed, an existing `auto` configuration can resolve to a different
+backend; resumed runs may therefore reject and recompute backend-dependent artifacts. Pin an
+explicit backend when preserving the previous decoder is required.
 
 SAM2-based tissue segmentation requires a separate additional install:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@
   - Input CSV schemas, config areas, progress reporting, and resume/precomputed workflows
 - [Artifact reference](artifacts.md)
   - `process_list.csv` manifests
+- [Release notes](release-notes.md)
+  - User-visible behavior changes and artifact compatibility impact
 - [Benchmark notes](benchmark.md)
   - Throughput findings and the benchmark entrypoints in `scripts/`
 - [Tissue mask generation](tissue-mask-generation.md)

--- a/docs/adr/0002-independent-mask-backend.md
+++ b/docs/adr/0002-independent-mask-backend.md
@@ -19,6 +19,10 @@ roles are independent, and neither role's openability probe influences the other
 one selection policy: `auto` checks openability only (open then close to pick the first backend
 that opens the file) and never inspects decoded label semantics or retries after selection. A
 selected decoder is authoritative for that read (ADR 0001 still holds).
+The shared automatic priority is cuCIM, VIPS, OpenSlide, then ASAP. A slide probe receives the
+user's level-0 spacing override so it can open a slide with missing native spacing metadata;
+probe-time spacing-conflict warnings are suppressed, and only the selected reader emits the
+contextual warning.
 
 Both fields accept only `auto`, `cucim`, `asap`, `openslide`, `vips`; null and unknown values
 fail configuration validation, including when a `TilingConfig` is constructed directly in
@@ -53,5 +57,7 @@ resolved backend, and reason.
 - A mask can use a different decoder than its slide without changing the slide backend.
 - Because `auto` is openability-only, a backend that opens but cannot decode a mask can be
   selected and then fail at read time; the fix is to set `mask_backend` explicitly.
+- Existing `auto` configurations can resolve to a different backend under the shared priority,
+  so backend-dependent artifacts may need to be recomputed.
 - Pre-#163 metadata and `process_list.csv` schemas (without the mask backend fields/columns)
   are rejected clearly rather than loaded.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,23 @@
+# Release Notes
+
+## Unreleased
+
+### Shared automatic slide and mask backend priority
+
+Automatic selection now probes both slide and source-mask paths independently with the same
+openability-only priority:
+
+`cucim -> vips -> openslide -> asap`
+
+Explicit backend choices remain authoritative. Automatic selection still stops at the first
+reader that opens a source; it does not inspect mask labels or retry after a later decode
+failure.
+
+Slide probes now receive `spacing_at_level_0`, allowing the override to rescue missing native
+spacing metadata during automatic selection. Probe-time spacing-discrepancy warnings are
+suppressed, while the selected reader continues to emit the single contextual warning.
+
+This priority change can select a different resolved backend for an existing configuration
+that uses `auto`. Because resume compatibility records the resolved slide and mask backends,
+previous backend-dependent artifacts may be rejected and recomputed. Pin `backend` and
+`mask_backend` explicitly when preserving the previous decoder is required.

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -95,6 +95,7 @@ def _resolve_effective_backends(
         requested_mask_backend=tiling.requested_mask_backend,
         wsi_path=whole_slide.image_path,
         mask_path=whole_slide.mask_path,
+        slide_spacing_override=whole_slide.spacing_at_level_0,
     )
     if emit and resolved.slide.reason is not None:
         emit_progress(

--- a/hs2p/wsi/reader.py
+++ b/hs2p/wsi/reader.py
@@ -1,4 +1,5 @@
 
+import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -17,7 +18,7 @@ from hs2p.wsi.backends import (
 from hs2p.wsi.geometry import LevelSelection, select_level, select_level_for_downsample
 
 AUTO_BACKEND = "auto"
-AUTO_BACKEND_ORDER = ("cucim", "asap", "openslide")
+AUTO_BACKEND_ORDER = ("cucim", "vips", "openslide", "asap")
 
 
 @runtime_checkable
@@ -107,6 +108,7 @@ def resolve_backends(
     requested_mask_backend: str | None,
     wsi_path: str | Path,
     mask_path: str | Path | None = None,
+    slide_spacing_override: float | None = None,
 ) -> ResolvedBackends:
     """Resolve slide and mask backends independently from their own paths.
 
@@ -115,7 +117,11 @@ def resolve_backends(
     probe. A slide with no ``mask_path`` resolves only the slide role.
     """
     requested_slide = (requested_slide_backend or AUTO_BACKEND).strip().lower()
-    slide_selection = resolve_backend(requested_slide, wsi_path=Path(wsi_path))
+    slide_selection = resolve_backend(
+        requested_slide,
+        wsi_path=Path(wsi_path),
+        spacing_override=slide_spacing_override,
+    )
     if mask_path is None:
         return ResolvedBackends(
             slide=slide_selection,
@@ -198,7 +204,11 @@ def open_slide(
 ) -> SlideReader:
     backend = (backend or AUTO_BACKEND).strip().lower()
     if backend == AUTO_BACKEND:
-        selection = resolve_backend(backend, wsi_path=Path(path))
+        selection = resolve_backend(
+            backend,
+            wsi_path=Path(path),
+            spacing_override=spacing_override,
+        )
         backend = selection.backend
     spec = _BACKENDS.get(backend)
     if spec is None:
@@ -216,25 +226,32 @@ def _normalize_path(path: Path | None) -> str | None:
 
 
 @lru_cache(maxsize=256)
-def _backend_can_open_slide(
+def _backend_can_open_source(
     *,
-    wsi_path: str,
-    mask_path: str | None,
+    source_path: str,
+    companion_path: str | None,
     backend: str,
+    spacing_override: float | None = None,
 ) -> bool:
     spec = _BACKENDS.get(backend)
     if spec is None:
         return False
-    if not spec.supports_path(wsi_path):
+    if not spec.supports_path(source_path):
         return False
-    if mask_path is not None and not spec.supports_path(mask_path):
+    if companion_path is not None and not spec.supports_path(companion_path):
         return False
     try:
-        slide = spec.opener(wsi_path)
-        slide.close()
-        if mask_path is not None:
-            mask = spec.opener(mask_path)
-            mask.close()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"^Slide spacing override conflict:",
+                category=UserWarning,
+            )
+            source = spec.opener(source_path, spacing_override=spacing_override)
+            source.close()
+            if companion_path is not None:
+                companion = spec.opener(companion_path)
+                companion.close()
         return True
     except Exception:
         return False
@@ -245,6 +262,7 @@ def resolve_backend(
     *,
     wsi_path: Path,
     mask_path: Path | None = None,
+    spacing_override: float | None = None,
 ) -> BackendSelection:
     requested_backend = (requested_backend or AUTO_BACKEND).strip().lower()
     if requested_backend != AUTO_BACKEND:
@@ -259,38 +277,40 @@ def resolve_backend(
     tried: list[str] = []
     reasons: list[str] = []
 
-    if supports_cucim_path(wsi_path):
-        tried.append("cucim")
-        if _backend_can_open_slide(
-            wsi_path=normalized_wsi_path,
-            mask_path=normalized_mask_path,
-            backend="cucim",
-        ):
-            return BackendSelection(
-                backend="cucim",
-                reason="selected cuCIM for auto backend",
-                tried=tuple(tried),
-            )
-        reasons.append("cuCIM could not open the slide or mask")
-    else:
-        reasons.append(
-            f"cuCIM skipped for unsupported slide suffix {wsi_path.suffix.lower() or '<none>'}"
+    display_names = {"cucim": "cuCIM", "vips": "VIPS"}
+    for backend in AUTO_BACKEND_ORDER:
+        spec = _BACKENDS[backend]
+        display_name = display_names.get(backend, backend)
+        unsupported_path = next(
+            (
+                path
+                for path in (normalized_wsi_path, normalized_mask_path)
+                if path is not None and not spec.supports_path(path)
+            ),
+            None,
         )
-
-    for backend in AUTO_BACKEND_ORDER[1:]:
+        if unsupported_path is not None:
+            suffix = Path(unsupported_path).suffix.lower() or "<none>"
+            reasons.append(
+                f"{display_name} skipped for unsupported path suffix {suffix}"
+            )
+            continue
         tried.append(backend)
-        if _backend_can_open_slide(
-            wsi_path=normalized_wsi_path,
-            mask_path=normalized_mask_path,
+        if _backend_can_open_source(
+            source_path=normalized_wsi_path,
+            companion_path=normalized_mask_path,
             backend=backend,
+            spacing_override=spacing_override,
         ):
-            reason = "; ".join(reasons + [f"selected {backend} for auto backend"])
+            reason = "; ".join(
+                reasons + [f"selected {display_name} for auto backend"]
+            )
             return BackendSelection(
                 backend=backend,
                 reason=reason,
                 tried=tuple(tried),
             )
-        reasons.append(f"{backend} could not open the slide or mask")
+        reasons.append(f"{display_name} could not open the source")
 
     raise RuntimeError(
         f"Unable to open {wsi_path} with any supported backend (tried: {', '.join(tried) or 'none'})"

--- a/hs2p/wsi/wsi.py
+++ b/hs2p/wsi/wsi.py
@@ -74,7 +74,11 @@ class WSI(object):
         # backend from ``path`` only, the mask backend from ``mask_path`` only. A slide with no
         # mask leaves both mask-provenance attributes ``None``.
         self.requested_backend = backend
-        selection = resolve_backend(backend, wsi_path=path)
+        selection = resolve_backend(
+            backend,
+            wsi_path=path,
+            spacing_override=spacing_at_level_0,
+        )
         self.backend = selection.backend
         self.reader = open_slide(
             path,

--- a/tests/test_annotation_coverage.py
+++ b/tests/test_annotation_coverage.py
@@ -34,8 +34,14 @@ TUMOR_PX, STROMA_PX, NECROSIS_PX = 40000, 40000, 1600
 
 
 def _fake_resolve_backends(
-    *, requested_slide_backend, requested_mask_backend, wsi_path, mask_path=None
+    *,
+    requested_slide_backend,
+    requested_mask_backend,
+    wsi_path,
+    mask_path=None,
+    slide_spacing_override=None,
 ):
+    del slide_spacing_override
     from hs2p.wsi.backend import BackendSelection, ResolvedBackends
 
     sel = BackendSelection(backend="asap", reason=None, tried=("asap",))

--- a/tests/test_backend_selection.py
+++ b/tests/test_backend_selection.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -70,9 +71,14 @@ def _cucim_auto_backend_selection(
 
 
 def _cucim_auto_resolve_backends(
-    *, requested_slide_backend: str, requested_mask_backend, wsi_path: Path, mask_path=None
+    *,
+    requested_slide_backend: str,
+    requested_mask_backend,
+    wsi_path: Path,
+    mask_path=None,
+    slide_spacing_override=None,
 ) -> backend_mod.ResolvedBackends:
-    del wsi_path
+    del wsi_path, slide_spacing_override
     slide = _cucim_auto_backend_selection("auto", wsi_path=Path("slide.svs"))
     mask = (
         None
@@ -90,12 +96,18 @@ def _cucim_auto_resolve_backends(
 def test_resolve_backend_prefers_cucim_when_supported(monkeypatch):
     calls: list[str] = []
 
-    def _fake_can_open_slide(*, wsi_path: str, mask_path: str | None, backend: str):
-        del wsi_path, mask_path
+    def _fake_can_open_source(
+        *,
+        source_path: str,
+        companion_path: str | None,
+        backend: str,
+        spacing_override=None,
+    ):
+        del source_path, companion_path, spacing_override
         calls.append(backend)
         return backend == "cucim"
 
-    monkeypatch.setattr(reader_mod, "_backend_can_open_slide", _fake_can_open_slide)
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _fake_can_open_source)
 
     selection = backend_mod.resolve_backend("auto", wsi_path=Path("slide.svs"))
 
@@ -105,32 +117,161 @@ def test_resolve_backend_prefers_cucim_when_supported(monkeypatch):
     assert calls == ["cucim"]
 
 
-def test_resolve_backend_skips_cucim_for_known_unsupported_suffix(monkeypatch):
+def test_auto_slide_fallback_uses_shared_priority_without_native_backends(monkeypatch):
     calls: list[str] = []
 
-    def _fake_can_open_slide(*, wsi_path: str, mask_path: str | None, backend: str):
-        del wsi_path, mask_path
+    def _fake_can_open_source(
+        *,
+        source_path: str,
+        companion_path: str | None,
+        backend: str,
+        spacing_override: float | None = None,
+    ):
+        del source_path, companion_path
         calls.append(backend)
+        assert spacing_override == 0.25
+        return backend == "openslide"
+
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _fake_can_open_source)
+
+    selection = backend_mod.resolve_backend(
+        "auto",
+        wsi_path=Path("slide.svs"),
+        spacing_override=0.25,
+    )
+
+    assert selection.backend == "openslide"
+    assert selection.tried == ("cucim", "vips", "openslide")
+    assert calls == ["cucim", "vips", "openslide"]
+
+
+def test_auto_selection_skips_backends_that_do_not_support_the_path(monkeypatch):
+    calls: list[str] = []
+
+    def _fake_can_open_source(
+        *,
+        source_path: str,
+        companion_path: str | None,
+        backend: str,
+        spacing_override: float | None = None,
+    ):
+        del source_path, companion_path, spacing_override
+        calls.append(backend)
+        return backend == "openslide"
+
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _fake_can_open_source)
+
+    selection = backend_mod.resolve_backend("auto", wsi_path=Path("slide.dcm"))
+
+    assert selection.backend == "openslide"
+    assert selection.tried == ("openslide",)
+    assert calls == ["openslide"]
+
+
+def test_auto_mask_fallback_uses_shared_priority_independently(monkeypatch):
+    calls: list[tuple[str, str, float | None]] = []
+
+    def _fake_can_open_source(
+        *,
+        source_path: str,
+        companion_path: str | None,
+        backend: str,
+        spacing_override: float | None = None,
+    ):
+        del companion_path
+        calls.append((source_path, backend, spacing_override))
+        if source_path.endswith("slide.svs"):
+            return backend == "cucim"
         return backend == "asap"
 
-    monkeypatch.setattr(reader_mod, "_backend_can_open_slide", _fake_can_open_slide)
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _fake_can_open_source)
 
-    selection = backend_mod.resolve_backend("auto", wsi_path=Path("slide.mrxs"))
+    resolved = backend_mod.resolve_backends(
+        requested_slide_backend="auto",
+        requested_mask_backend="auto",
+        wsi_path=Path("slide.svs"),
+        mask_path=Path("mask.tif"),
+        slide_spacing_override=0.5,
+    )
 
-    assert selection.backend == "asap"
-    assert selection.tried == ("asap",)
-    assert calls == ["asap"]
+    assert resolved.slide_backend == "cucim"
+    assert resolved.mask_backend == "asap"
+    assert resolved.requested_slide_backend == "auto"
+    assert resolved.requested_mask_backend == "auto"
+    assert calls == [
+        ("slide.svs", "cucim", 0.5),
+        ("mask.tif", "cucim", None),
+        ("mask.tif", "vips", None),
+        ("mask.tif", "openslide", None),
+        ("mask.tif", "asap", None),
+    ]
+
+
+def test_auto_open_uses_spacing_override_for_probe_and_warns_only_on_selected_open(
+    monkeypatch,
+):
+    opened_with: list[float | None] = []
+
+    class _Reader:
+        def close(self):
+            return None
+
+    def _fake_opener(path, *, spacing_override=None, gpu_decode=False):
+        assert gpu_decode is False
+        opened_with.append(spacing_override)
+        if spacing_override is None:
+            raise ValueError("missing native spacing")
+        warnings.warn(
+            "Slide spacing override conflict: "
+            f"path={path}, native=0.5, supplied={spacing_override}, backend=cucim; "
+            "using the supplied level-0 spacing.",
+            UserWarning,
+        )
+        return _Reader()
+
+    monkeypatch.setattr(
+        reader_mod,
+        "_BACKENDS",
+        {
+            "cucim": reader_mod._BackendSpec(
+                name="cucim",
+                opener=_fake_opener,
+                supports_path=lambda path: True,
+            ),
+        },
+    )
+    reader_mod._backend_can_open_source.cache_clear()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        reader = reader_mod.open_slide(
+            Path("missing-spacing.svs"),
+            backend="auto",
+            spacing_override=0.25,
+        )
+        reader.close()
+
+    assert opened_with == [0.25, 0.25]
+    assert len(caught) == 1
+    assert "path=missing-spacing.svs" in str(caught[0].message)
+    assert "backend=cucim" in str(caught[0].message)
 
 
 def test_resolve_backend_respects_explicit_override(monkeypatch):
     calls: list[str] = []
 
-    def _fake_can_open_slide(*, wsi_path: str, mask_path: str | None, backend: str):
-        del wsi_path, mask_path, backend
+    def _fake_can_open_source(
+        *,
+        source_path: str,
+        companion_path: str | None,
+        backend: str,
+        spacing_override=None,
+    ):
+        del source_path, companion_path, backend, spacing_override
         calls.append("called")
         return False
 
-    monkeypatch.setattr(reader_mod, "_backend_can_open_slide", _fake_can_open_slide)
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _fake_can_open_source)
 
     selection = backend_mod.resolve_backend("asap", wsi_path=Path("slide.svs"))
 
@@ -143,12 +284,18 @@ def test_resolve_backend_respects_explicit_override(monkeypatch):
 def test_reader_resolve_backend_prefers_cucim_when_supported(monkeypatch):
     calls: list[str] = []
 
-    def _fake_can_open_slide(*, wsi_path: str, mask_path: str | None, backend: str):
-        del wsi_path, mask_path
+    def _fake_can_open_source(
+        *,
+        source_path: str,
+        companion_path: str | None,
+        backend: str,
+        spacing_override=None,
+    ):
+        del source_path, companion_path, spacing_override
         calls.append(backend)
         return backend == "cucim"
 
-    monkeypatch.setattr(reader_mod, "_backend_can_open_slide", _fake_can_open_slide)
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _fake_can_open_source)
 
     selection = reader_mod.resolve_backend("auto", wsi_path=Path("slide.svs"))
 
@@ -178,15 +325,14 @@ def test_reader_backend_probe_uses_backend_openers(monkeypatch):
             ),
         },
     )
-    reader_mod._backend_can_open_slide.cache_clear()
+    reader_mod._backend_can_open_source.cache_clear()
 
-    assert reader_mod._backend_can_open_slide(
-        wsi_path="/tmp/slide.tiff",
-        mask_path="/tmp/mask.tiff",
+    assert reader_mod._backend_can_open_source(
+        source_path="/tmp/slide.tiff",
+        companion_path="/tmp/mask.tiff",
         backend="cucim",
     )
     assert seen_paths == ["/tmp/slide.tiff", "/tmp/mask.tiff"]
-
 
 
 def test_wsi_opens_slide_and_mask_readers_with_resolved_backend(monkeypatch):
@@ -221,7 +367,10 @@ def test_wsi_opens_slide_and_mask_readers_with_resolved_backend(monkeypatch):
         seen_calls.append((path, backend, spacing_override))
         return _FakeSlideReader()
 
-    def _fake_resolve_backend(requested_backend, *, wsi_path, mask_path=None):
+    def _fake_resolve_backend(
+        requested_backend, *, wsi_path, mask_path=None, spacing_override=None
+    ):
+        del requested_backend, wsi_path, mask_path, spacing_override
         return backend_mod.BackendSelection(backend="cucim", tried=("cucim",))
 
     monkeypatch.setattr(wsi_mod, "resolve_backend", _fake_resolve_backend)
@@ -271,6 +420,48 @@ def test_tile_slide_uses_resolved_backend_for_hash_and_result(monkeypatch):
 
     assert result.backend == "cucim"
     assert captured["backend"] == "cucim"
+
+
+def test_effective_backend_resolution_forwards_level0_spacing_override(monkeypatch):
+    captured: dict[str, float | None] = {}
+
+    def _fake_resolve_backends(
+        *,
+        requested_slide_backend,
+        requested_mask_backend,
+        wsi_path,
+        mask_path=None,
+        slide_spacing_override=None,
+    ):
+        del requested_slide_backend, requested_mask_backend, wsi_path, mask_path
+        captured["slide_spacing_override"] = slide_spacing_override
+        return backend_mod.ResolvedBackends(
+            slide=backend_mod.BackendSelection(backend="cucim", tried=("cucim",)),
+            mask=None,
+            requested_slide_backend="auto",
+            requested_mask_backend=None,
+        )
+
+    monkeypatch.setattr(orchestration_mod, "resolve_backends", _fake_resolve_backends)
+
+    orchestration_mod._resolve_effective_backends(
+        api_mod.SlideSpec(
+            sample_id="missing-spacing",
+            image_path=Path("missing-spacing.svs"),
+            spacing_at_level_0=0.25,
+        ),
+        api_mod.TilingConfig(
+            requested_spacing_um=0.5,
+            requested_tile_size_px=256,
+            tolerance=0.05,
+            overlap=0.0,
+            min_coverage={"tissue": 0.1},
+            backend="auto",
+        ),
+        emit=False,
+    )
+
+    assert captured == {"slide_spacing_override": 0.25}
 
 
 def test_tile_slide_emits_backend_selection_progress_event(monkeypatch):

--- a/tests/test_mask_backend_pipeline.py
+++ b/tests/test_mask_backend_pipeline.py
@@ -270,7 +270,15 @@ def test_load_whole_slides_from_rows_preserves_mask_path():
 def test_auto_mask_selection_emits_distinct_progress_event(monkeypatch):
     reporter = RecordingReporter()
 
-    def _fake_resolve_backends(*, requested_slide_backend, requested_mask_backend, wsi_path, mask_path=None):
+    def _fake_resolve_backends(
+        *,
+        requested_slide_backend,
+        requested_mask_backend,
+        wsi_path,
+        mask_path=None,
+        slide_spacing_override=None,
+    ):
+        del slide_spacing_override
         slide = BackendSelection(backend="asap", reason=None, tried=("asap",))
         mask = BackendSelection(
             backend="cucim", reason="selected cuCIM for auto backend", tried=("cucim",)
@@ -309,7 +317,15 @@ def test_auto_mask_selection_emits_distinct_progress_event(monkeypatch):
 def test_maskless_slide_emits_no_mask_backend_event(monkeypatch):
     reporter = RecordingReporter()
 
-    def _fake_resolve_backends(*, requested_slide_backend, requested_mask_backend, wsi_path, mask_path=None):
+    def _fake_resolve_backends(
+        *,
+        requested_slide_backend,
+        requested_mask_backend,
+        wsi_path,
+        mask_path=None,
+        slide_spacing_override=None,
+    ):
+        del slide_spacing_override
         return ResolvedBackends(
             slide=BackendSelection(backend="cucim", reason="selected cuCIM for auto backend", tried=("cucim",)),
             mask=None, requested_slide_backend="auto", requested_mask_backend=None,
@@ -334,7 +350,10 @@ def test_maskless_slide_emits_no_mask_backend_event(monkeypatch):
 def test_wsi_resolves_mask_backend_independently(monkeypatch):
     opened: list[tuple[str, str]] = []
 
-    def _fake_resolve_backend(requested, *, wsi_path, mask_path=None):
+    def _fake_resolve_backend(
+        requested, *, wsi_path, mask_path=None, spacing_override=None
+    ):
+        del requested, mask_path, spacing_override
         # slide path -> asap; mask path -> openslide (independent)
         backend = "openslide" if "mask" in str(wsi_path) else "asap"
         return BackendSelection(backend=backend, reason=None, tried=(backend,))

--- a/tests/test_mask_backend_resolution.py
+++ b/tests/test_mask_backend_resolution.py
@@ -47,15 +47,17 @@ def _wsi(*, backend_name: str = "cucim"):
 def test_seam_resolves_slide_and_mask_from_own_paths(monkeypatch):
     seen: list[tuple[str, str]] = []
 
-    def _fake_can_open(*, wsi_path, mask_path, backend):
-        del mask_path
-        seen.append((str(wsi_path), backend))
+    def _fake_can_open(
+        *, source_path, companion_path, backend, spacing_override=None
+    ):
+        del companion_path, spacing_override
+        seen.append((str(source_path), backend))
         # slide.svs → cucim opens; mask.tif → only asap opens
-        if "mask" in str(wsi_path):
+        if "mask" in str(source_path):
             return backend == "asap"
         return backend == "cucim"
 
-    monkeypatch.setattr(reader_mod, "_backend_can_open_slide", _fake_can_open)
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _fake_can_open)
 
     resolved = resolve_backends(
         requested_slide_backend="auto",
@@ -73,8 +75,10 @@ def test_seam_resolves_slide_and_mask_from_own_paths(monkeypatch):
 def test_seam_maskless_has_null_mask_provenance(monkeypatch):
     monkeypatch.setattr(
         reader_mod,
-        "_backend_can_open_slide",
-        lambda *, wsi_path, mask_path, backend: backend == "cucim",
+        "_backend_can_open_source",
+        lambda *, source_path, companion_path, backend, spacing_override=None: (
+            backend == "cucim"
+        ),
     )
     resolved = resolve_backends(
         requested_slide_backend="auto",
@@ -93,14 +97,17 @@ def test_seam_slide_resolution_ignores_mask_openability(monkeypatch):
     with the slide's chosen backend must not perturb slide selection."""
     probed_paths: list[str] = []
 
-    def _fake_can_open(*, wsi_path, mask_path, backend):
-        probed_paths.append(str(wsi_path))
+    def _fake_can_open(
+        *, source_path, companion_path, backend, spacing_override=None
+    ):
+        del companion_path, spacing_override
+        probed_paths.append(str(source_path))
         # cucim can open the slide; the mask is a different format only asap opens
-        if "mask" in str(wsi_path):
+        if "mask" in str(source_path):
             return backend == "asap"
         return backend == "cucim"
 
-    monkeypatch.setattr(reader_mod, "_backend_can_open_slide", _fake_can_open)
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _fake_can_open)
     resolved = resolve_backends(
         requested_slide_backend="auto",
         requested_mask_backend="asap",
@@ -116,7 +123,7 @@ def test_seam_explicit_backends_are_authoritative_without_probe(monkeypatch):
     def _boom(*args, **kwargs):
         raise AssertionError("explicit backend must not trigger an openability probe")
 
-    monkeypatch.setattr(reader_mod, "_backend_can_open_slide", _boom)
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _boom)
     resolved = resolve_backends(
         requested_slide_backend="openslide",
         requested_mask_backend="cucim",


### PR DESCRIPTION
## Summary

- apply one automatic priority to independently resolved slide and mask sources: cuCIM → VIPS → OpenSlide → ASAP
- pass `spacing_at_level_0` into slide probes so automatic selection can rescue missing native spacing metadata
- suppress probe-time spacing-conflict warnings while preserving the selected reader's single contextual warning
- keep explicit backends authoritative, openability-only selection, and requested/resolved provenance unchanged
- document the priority change and potential backend-dependent artifact recomputation

## Root cause

The documented shared policy had not been applied to the runtime resolver: ASAP was still ahead of VIPS/OpenSlide, and automatic slide probes opened readers without the user's spacing override. That could select a different backend than documented or reject slides whose missing native spacing was otherwise recoverable.

## Validation

- TDD red cases cover deterministic slide and mask fallback chains, unsupported-path skipping, slide-only spacing propagation, missing-spacing rescue, and warning cardinality
- fix-forward rebased onto `origin/main` at `49d787c`, preserving the merged batch, encoder, spacing, coordinate-reuse, and resume contracts without conflicts
- cross-contract focused suite: `python -m pytest -q tests/test_backend_selection.py tests/test_mask_backend_resolution.py tests/test_mask_backend_pipeline.py tests/test_wsi_reader_protocol.py tests/test_annotation_coverage.py tests/test_coordinate_reuse_outputs.py tests/test_cli_smoke.py tests/test_progress.py tests/test_tiling_api.py tests/test_config_loading.py` — 230 passed, 3 skipped
- full default suite: `python -m pytest -q` — 454 passed, 3 skipped, 46 deselected
- Standards review: one private probe naming finding fixed; no remaining findings
- Spec review: no findings; rebase caused no semantic change, so no review axis required rerunning
- `git diff --check origin/main...HEAD`: clean

Closes #178
