### PR TITLE
Prevent image upsampling in spacing-aware reads

### DIFF
--- a/.tasks/issue-197.md
+++ b/.tasks/issue-197.md
@@ -1,0 +1,36 @@
+# Issue #197 — Content-aware spacing-read upsampling policy
+
+## Scope
+
+- [x] Centralize the image-versus-label upsampling decision in the spacing-read
+      planner and reuse that decision for full reads.
+- [x] Make public region/full spacing reads image-safe by default.
+- [x] Keep finer label reads available only through explicit label semantics and
+      nearest-neighbour interpolation.
+- [x] Remove the duplicate tiling pre-check and identify tiling reads as image
+      content.
+- [x] Document the image/label asymmetry and safe public defaults.
+
+## Pre-agreed public seams
+
+The issue acceptance criteria explicitly define these behavior seams:
+
+- `plan_spacing_read(...)`: centralized content-kind validation and finer-than-level-0
+  policy.
+- `WSI.read_region_at_spacing(...)`: image-safe default before backend access.
+- `WSI.read_full_at_spacing(...)`: the same policy before loading a full level.
+- `read_label_region_at_spacing(...)` and `read_label_at_spacing(...)`: explicit
+  label semantics with exact nearest-neighbour output.
+- `generate_tiles(...)`: centralized planner policy after duplicate-check removal.
+
+## TDD / verification
+
+- [x] Red → green: image planner rejects forbidden upsampling and validates content
+      kinds while tolerance/exact/downsample behavior stays intact.
+- [x] Red → green: region/full public defaults reject before backend access.
+- [x] Red → green: label helpers permit finer reads and return exact replicated labels.
+- [x] Red → green: `generate_tiles` reaches the shared image policy.
+- [x] Run focused spacing-read and tiling regressions.
+- [x] Run the full test suite.
+- [x] Run Standards and Spec reviews against `main`; fix findings and re-green.
+- [ ] Commit, push, and open a PR containing `Closes #197`.

--- a/hs2p/tiling/generate.py
+++ b/hs2p/tiling/generate.py
@@ -54,15 +54,6 @@ def generate_tiles(
     num_workers: int = 1,
 ) -> TileGeometry:
     normalized_downsamples = _normalize_level_downsamples(level_downsamples)
-    if requested_spacing_um < base_spacing_um:
-        relative_diff = abs(base_spacing_um - requested_spacing_um) / requested_spacing_um
-        if relative_diff > tolerance:
-            raise ValueError(
-                f"Desired spacing ({requested_spacing_um}) is smaller than the "
-                f"whole-slide image starting spacing ({base_spacing_um}) and does not "
-                f"fall within tolerance ({tolerance:.0%})"
-            )
-
     level_sel = plan_spacing_read(
         requested_spacing_um=requested_spacing_um,
         level0_spacing_um=base_spacing_um,
@@ -72,6 +63,7 @@ def generate_tiles(
         ],
         target_size_px=(requested_tile_size_px, requested_tile_size_px),
         tolerance=tolerance,
+        content_kind="image",
     )
     read_tile_size_px = level_sel.read_size_px[0]
     tile_size_lv0 = round(

--- a/hs2p/wsi/geometry.py
+++ b/hs2p/wsi/geometry.py
@@ -1,7 +1,11 @@
 
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
+
+# Pixel semantics controlling whether finer-than-source reads may upsample.
+ContentKind = Literal["image", "label"]
 
 
 @dataclass(frozen=True)
@@ -107,6 +111,42 @@ def select_level(
     )
 
 
+def select_level_for_spacing_read(
+    *,
+    requested_spacing_um: float,
+    level0_spacing_um: float,
+    level_downsamples: list[tuple[float, float]],
+    tolerance: float,
+    content_kind: ContentKind,
+) -> LevelSelection:
+    """Select a level and enforce the content-aware upsampling policy.
+
+    Image pixels may only be read at native or coarser spacing; label pixels may
+    be replicated because nearest-neighbour interpolation preserves their vocabulary.
+    """
+    if content_kind not in ("image", "label"):
+        raise ValueError(
+            f"unknown content_kind {content_kind!r}; expected 'image' or 'label'"
+        )
+    selection = select_level(
+        requested_spacing_um=requested_spacing_um,
+        level0_spacing_um=level0_spacing_um,
+        level_downsamples=level_downsamples,
+        tolerance=tolerance,
+    )
+    if (
+        content_kind == "image"
+        and requested_spacing_um < level0_spacing_um
+        and not selection.is_within_tolerance
+    ):
+        raise ValueError(
+            f"requested spacing {requested_spacing_um} µm/px is finer than finest "
+            f"available spacing {level0_spacing_um} µm/px; "
+            "image upsampling is forbidden"
+        )
+    return selection
+
+
 @dataclass(frozen=True)
 class SpacingReadPlan:
     """How to read a region of ``target_size_px`` (at ``requested_spacing_um``).
@@ -130,6 +170,7 @@ def plan_spacing_read(
     level_downsamples: list[tuple[float, float]],
     target_size_px: tuple[int, int],
     tolerance: float,
+    content_kind: ContentKind,
 ) -> SpacingReadPlan:
     """Resolve (level, read_size) for reading ``target_size_px`` at a spacing.
 
@@ -138,13 +179,16 @@ def plan_spacing_read(
     requested spacing (via :func:`select_level`), then size the read at that level to
     cover ``target_size_px`` after downscaling. Within tolerance ⇒ read the target
     size directly (treated as exact); otherwise scale up by
-    ``requested_spacing_um / read_spacing_um``.
+    ``requested_spacing_um / read_spacing_um``. ``content_kind`` is explicit:
+    ``"image"`` forbids finer-than-source requests outside tolerance, while
+    ``"label"`` allows nearest-neighbour replication by the caller.
     """
-    sel = select_level(
+    sel = select_level_for_spacing_read(
         requested_spacing_um=requested_spacing_um,
         level0_spacing_um=level0_spacing_um,
         level_downsamples=level_downsamples,
         tolerance=tolerance,
+        content_kind=content_kind,
     )
     target_w, target_h = int(target_size_px[0]), int(target_size_px[1])
     if sel.is_within_tolerance:

--- a/hs2p/wsi/masks.py
+++ b/hs2p/wsi/masks.py
@@ -11,12 +11,15 @@ def read_label_at_spacing(
 ) -> np.ndarray:
     """Read a multi-class label raster at ``requested_spacing_um``, preserving class ids.
 
-    Resamples with **nearest-neighbor** (any averaging interpolation would invent
-    class indices) via :meth:`hs2p.wsi.wsi.WSI.read_full_at_spacing`, then recovers a
-    single-channel integer raster. Slide backends return RGB (a single-channel label
-    is replicated across channels); this collapses it back to one channel, asserting
-    the channels agree so a genuine colour image fails loud rather than silently
-    keeping only its red channel.
+    Explicitly identifies the pixels as labels and resamples with
+    **nearest-neighbor** (any averaging interpolation would invent class indices) via
+    :meth:`hs2p.wsi.wsi.WSI.read_full_at_spacing`. Unlike the image-safe public
+    default, this permits finer requests because nearest-neighbour replication
+    preserves the label vocabulary. The result is recovered as a single-channel
+    integer raster. Slide backends return RGB (a single-channel label is replicated
+    across channels); this collapses it back to one channel, asserting the channels
+    agree so a genuine colour image fails loud rather than silently keeping only its
+    red channel.
 
     Args:
         wsi: An :class:`hs2p.wsi.wsi.WSI` (or any object exposing
@@ -28,7 +31,10 @@ def read_label_at_spacing(
         A 2-D integer ``np.ndarray`` of class indices at the requested spacing.
     """
     arr = wsi.read_full_at_spacing(
-        requested_spacing_um, tolerance=tolerance, interpolation="nearest"
+        requested_spacing_um,
+        tolerance=tolerance,
+        interpolation="nearest",
+        content_kind="label",
     )
     return _collapse_label_raster(arr)
 
@@ -43,9 +49,10 @@ def read_label_region_at_spacing(
 ) -> np.ndarray:
     """Read a multi-class label *region* at ``requested_spacing_um``, preserving class ids.
 
-    The region counterpart of :func:`read_label_at_spacing` (for annotation-sampled ROIs):
-    nearest-neighbor resample via :meth:`hs2p.wsi.wsi.WSI.read_region_at_spacing`, then
-    collapse the channel-replicated raster back to a single-channel integer mask.
+    The region counterpart of :func:`read_label_at_spacing` (for annotation-sampled
+    ROIs): explicitly opt into label upsampling, nearest-neighbor resample via
+    :meth:`hs2p.wsi.wsi.WSI.read_region_at_spacing`, then collapse the
+    channel-replicated raster back to a single-channel integer mask.
 
     Args:
         location: ``(x, y)`` top-left in level-0 pixel space.
@@ -57,6 +64,7 @@ def read_label_region_at_spacing(
         size,
         tolerance=tolerance,
         interpolation="nearest",
+        content_kind="label",
     )
     return _collapse_label_raster(arr)
 

--- a/hs2p/wsi/wsi.py
+++ b/hs2p/wsi/wsi.py
@@ -5,7 +5,11 @@ import numpy as np
 from PIL import Image
 
 from hs2p.wsi.backend import open_mask_reader, open_slide, resolve_backend
-from hs2p.wsi.geometry import plan_spacing_read, select_level
+from hs2p.wsi.geometry import (
+    ContentKind,
+    plan_spacing_read,
+    select_level_for_spacing_read,
+)
 
 Image.MAX_IMAGE_PIXELS = 933120000
 
@@ -19,6 +23,18 @@ INTERPOLATION_FLAGS = {
     "cubic": cv2.INTER_CUBIC,
     "lanczos": cv2.INTER_LANCZOS4,
 }
+
+
+def _validate_label_resize_interpolation(
+    *,
+    content_kind: ContentKind,
+    interpolation: str,
+    needs_resize: bool,
+) -> None:
+    if content_kind == "label" and needs_resize and interpolation != "nearest":
+        raise ValueError(
+            "label content requires nearest-neighbour interpolation when resizing"
+        )
 
 
 def resize_array(
@@ -227,14 +243,16 @@ class WSI(object):
         *,
         tolerance: float,
         interpolation: str,
+        content_kind: ContentKind = "image",
     ) -> np.ndarray:
         """Read a region at an arbitrary spacing (level-select + downscale).
 
         Picks the finest pyramid level whose spacing is ``<= requested_spacing_um``
-        (within ``tolerance``) — never upsampling — reads it natively, then downscales
-        to ``size`` (width, height in px at ``requested_spacing_um``) with the named
-        ``interpolation``. When a level matches the requested spacing exactly there is
-        no resize (lossless).
+        (within ``tolerance``), reads it natively, then resizes to ``size`` (width,
+        height in px at ``requested_spacing_um``). The safe default treats pixels as
+        image content and never upsamples them. Label helpers explicitly opt into
+        nearest-neighbour replication. A level within tolerance is accepted without
+        resizing.
 
         Args:
             location: ``(x, y)`` top-left in level-0 pixel space.
@@ -244,7 +262,11 @@ class WSI(object):
                 the caller must state it).
             interpolation: One of :data:`INTERPOLATION_FLAGS`, required so the caller
                 consciously picks it (``"nearest"`` for label masks, ``"area"`` for
-                image downscaling).
+                image downscaling). Resizing declared label content with any other
+                interpolation raises rather than inventing label values.
+            content_kind: Pixel semantics. The safe default, ``"image"``, forbids
+                requests finer than the finest available spacing outside tolerance.
+                ``"label"`` allows nearest-neighbour replication for label helpers.
         """
         plan = plan_spacing_read(
             requested_spacing_um=float(requested_spacing_um),
@@ -252,9 +274,16 @@ class WSI(object):
             level_downsamples=self.level_downsamples,
             target_size_px=(int(size[0]), int(size[1])),
             tolerance=float(tolerance),
+            content_kind=content_kind,
+        )
+        target_size = (int(size[0]), int(size[1]))
+        _validate_label_resize_interpolation(
+            content_kind=content_kind,
+            interpolation=interpolation,
+            needs_resize=not plan.is_within_tolerance,
         )
         region = self.read_region(location, plan.level, plan.read_size_px)
-        return resize_array(region, (int(size[0]), int(size[1])), interpolation=interpolation)
+        return resize_array(region, target_size, interpolation=interpolation)
 
     def read_full_at_spacing(
         self,
@@ -262,19 +291,28 @@ class WSI(object):
         *,
         tolerance: float,
         interpolation: str,
+        content_kind: ContentKind = "image",
     ) -> np.ndarray:
         """Read the entire image resampled to ``requested_spacing_um``.
 
-        Convenience over :meth:`read_region_at_spacing` for the "read this whole
-        (small) image at a target spacing" case (e.g. a pre-cropped ROI tile): full
-        native read of the finest level ``<=`` the request, then downscale by
-        ``level_spacing / requested_spacing_um``. Exact-level match ⇒ no resize.
+        Full native read of the finest level ``<=`` the request, then downscale by
+        ``level_spacing / requested_spacing_um``. The safe ``content_kind="image"``
+        default rejects requests finer than the finest available spacing outside
+        tolerance. ``content_kind="label"`` permits nearest-neighbour replication
+        for label helpers and rejects other interpolation when resampling. A level
+        within tolerance is returned without resizing.
         """
-        sel = select_level(
+        sel = select_level_for_spacing_read(
             requested_spacing_um=float(requested_spacing_um),
             level0_spacing_um=float(self.get_level_spacing(0)),
             level_downsamples=self.level_downsamples,
             tolerance=float(tolerance),
+            content_kind=content_kind,
+        )
+        _validate_label_resize_interpolation(
+            content_kind=content_kind,
+            interpolation=interpolation,
+            needs_resize=not sel.is_within_tolerance,
         )
         arr = self.get_slide(sel.level)
         if sel.is_within_tolerance:

--- a/tests/test_preprocessing_core.py
+++ b/tests/test_preprocessing_core.py
@@ -104,6 +104,31 @@ def test_generate_tiles_uses_actual_read_geometry_when_spacing_is_within_toleran
     assert np.unique(result.y)[1] == 448
 
 
+def test_generate_tiles_rejects_finer_image_spacing_via_shared_policy():
+    contours = ContourResult(
+        contours=[],
+        holes=[],
+        mask=np.zeros((1, 1), dtype=np.uint8),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"requested spacing 0\.125.*finest available spacing 0\.25.*"
+            r"image upsampling is forbidden"
+        ),
+    ):
+        generate_tiles(
+            slide_dimensions=(100, 100),
+            contours=contours,
+            requested_tile_size_px=256,
+            requested_spacing_um=0.125,
+            base_spacing_um=0.25,
+            level_downsamples=[1.0],
+            tolerance=0.05,
+        )
+
+
 def _make_tiling_result(n_tiles: int = 4) -> TilingResult:
     rng = np.random.RandomState(42)
     coords = rng.randint(0, 1000, size=(n_tiles, 2)).astype(np.int64)

--- a/tests/test_spacing_read_primitives.py
+++ b/tests/test_spacing_read_primitives.py
@@ -3,8 +3,8 @@
 Covers the shared planning kernel (:func:`plan_spacing_read`), the resize helper
 (:func:`resize_array`), and the three public read methods built on them:
 ``WSI.read_region_at_spacing``, ``WSI.read_full_at_spacing``, and
-``read_label_at_spacing``. The WSI methods are exercised against a lightweight
-stub (they only touch ``get_level_spacing``, ``level_downsamples``,
+the full and regional label helpers. The WSI methods are exercised against a
+lightweight stub (they only touch ``get_level_spacing``, ``level_downsamples``,
 ``read_region``, and ``get_slide``) so no slide backend is required.
 """
 
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 
 from hs2p.wsi.geometry import plan_spacing_read
-from hs2p.wsi.masks import read_label_at_spacing
+from hs2p.wsi.masks import read_label_at_spacing, read_label_region_at_spacing
 from hs2p.wsi.wsi import WSI, resize_array
 
 # level0 spacing 0.5 µm/px with x1/x2/x4 downsamples -> spacings [0.5, 1.0, 2.0]
@@ -29,6 +29,7 @@ def test_plan_spacing_read_exact_match_reads_target_size_directly():
         level_downsamples=DOWNSAMPLES,
         target_size_px=(100, 100),
         tolerance=0.05,
+        content_kind="image",
     )
 
     assert plan.level == 0
@@ -46,6 +47,7 @@ def test_plan_spacing_read_out_of_tolerance_scales_read_size_up():
         level_downsamples=DOWNSAMPLES,
         target_size_px=(100, 100),
         tolerance=0.05,
+        content_kind="image",
     )
 
     assert plan.level == 1
@@ -63,12 +65,64 @@ def test_plan_spacing_read_never_selects_a_coarser_level_than_requested():
         level_downsamples=DOWNSAMPLES,
         target_size_px=(100, 100),
         tolerance=0.05,
+        content_kind="image",
     )
 
     assert plan.level == 0
     assert plan.read_spacing_um == pytest.approx(0.5)
     assert plan.is_within_tolerance is False
     assert plan.read_size_px == (180, 180)  # round(100 * 0.9 / 0.5)
+
+
+def test_plan_spacing_read_rejects_finer_image_request_outside_tolerance():
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"requested spacing 0\.25.*finest available spacing 0\.5.*"
+            r"image upsampling is forbidden"
+        ),
+    ):
+        plan_spacing_read(
+            requested_spacing_um=0.25,
+            level0_spacing_um=0.5,
+            level_downsamples=DOWNSAMPLES,
+            target_size_px=(100, 100),
+            tolerance=0.05,
+            content_kind="image",
+        )
+
+
+def test_plan_spacing_read_rejects_unknown_content_kind():
+    with pytest.raises(
+        ValueError,
+        match=r"unknown content_kind 'mask'; expected 'image' or 'label'",
+    ):
+        plan_spacing_read(
+            requested_spacing_um=0.5,
+            level0_spacing_um=0.5,
+            level_downsamples=DOWNSAMPLES,
+            target_size_px=(100, 100),
+            tolerance=0.05,
+            content_kind="mask",
+        )
+
+
+@pytest.mark.parametrize("content_kind", ["image", "label"])
+def test_plan_spacing_read_accepts_slightly_finer_spacing_within_tolerance_without_resize(
+    content_kind,
+):
+    plan = plan_spacing_read(
+        requested_spacing_um=0.49,
+        level0_spacing_um=0.5,
+        level_downsamples=DOWNSAMPLES,
+        target_size_px=(100, 100),
+        tolerance=0.05,
+        content_kind=content_kind,
+    )
+
+    assert plan.level == 0
+    assert plan.is_within_tolerance is True
+    assert plan.read_size_px == (100, 100)
 
 
 # --------------------------------------------------------------------------- #
@@ -113,9 +167,14 @@ def test_resize_array_rejects_unknown_interpolation():
 class _StubWSI:
     """Minimal duck-typed stand-in for the attributes the read methods touch."""
 
+    read_full_at_spacing = WSI.read_full_at_spacing
+    read_region_at_spacing = WSI.read_region_at_spacing
+
     def __init__(self, *, level0_spacing_um: float, levels: list[np.ndarray]):
         self._level0_spacing_um = level0_spacing_um
         self._levels = levels
+        self.read_region_calls = 0
+        self.get_slide_calls = 0
         width_0, height_0 = levels[0].shape[1], levels[0].shape[0]
         self.level_downsamples = [
             (width_0 / lvl.shape[1], height_0 / lvl.shape[0]) for lvl in levels
@@ -125,9 +184,11 @@ class _StubWSI:
         return self._level0_spacing_um * self.level_downsamples[level][0]
 
     def get_slide(self, level: int) -> np.ndarray:
+        self.get_slide_calls += 1
         return self._levels[level]
 
     def read_region(self, location, level, size):
+        self.read_region_calls += 1
         x, y = location
         ds = self.level_downsamples[level][0]
         arr = self._levels[level]
@@ -153,12 +214,98 @@ def test_read_region_at_spacing_exact_match_returns_native_region_unresized():
     np.testing.assert_array_equal(region, level0[2:6, 2:6, :])
 
 
+def test_read_region_at_spacing_defaults_to_image_and_rejects_before_backend_read():
+    level0 = np.zeros((8, 8, 3), dtype=np.uint8)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    with pytest.raises(ValueError, match="image upsampling is forbidden"):
+        WSI.read_region_at_spacing(
+            stub,
+            location=(2, 2),
+            requested_spacing_um=0.25,
+            size=(4, 4),
+            tolerance=0.05,
+            interpolation="nearest",
+        )
+
+    assert stub.read_region_calls == 0
+
+
+def test_read_region_at_spacing_rejects_averaging_when_resizing_labels():
+    level0 = np.zeros((8, 8, 3), dtype=np.uint8)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    with pytest.raises(
+        ValueError,
+        match="label content requires nearest-neighbour interpolation when resizing",
+    ):
+        WSI.read_region_at_spacing(
+            stub,
+            location=(0, 0),
+            requested_spacing_um=0.25,
+            size=(4, 4),
+            tolerance=0.05,
+            interpolation="area",
+            content_kind="label",
+        )
+
+    assert stub.read_region_calls == 0
+
+
 def test_read_full_at_spacing_exact_match_returns_level_unchanged():
     level0 = np.arange(4 * 4 * 3, dtype=np.uint8).reshape(4, 4, 3)
     stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
 
     out = WSI.read_full_at_spacing(
         stub, requested_spacing_um=0.5, tolerance=0.05, interpolation="area"
+    )
+
+    assert out is level0
+
+
+def test_read_full_at_spacing_defaults_to_image_and_rejects_before_backend_load():
+    level0 = np.zeros((4, 4, 3), dtype=np.uint8)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    with pytest.raises(ValueError, match="image upsampling is forbidden"):
+        WSI.read_full_at_spacing(
+            stub,
+            requested_spacing_um=0.25,
+            tolerance=0.05,
+            interpolation="nearest",
+        )
+
+    assert stub.get_slide_calls == 0
+
+
+def test_read_full_at_spacing_rejects_averaging_when_resizing_labels():
+    level0 = np.zeros((4, 4, 3), dtype=np.uint8)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    with pytest.raises(
+        ValueError,
+        match="label content requires nearest-neighbour interpolation when resizing",
+    ):
+        WSI.read_full_at_spacing(
+            stub,
+            requested_spacing_um=0.25,
+            tolerance=0.05,
+            interpolation="area",
+            content_kind="label",
+        )
+
+    assert stub.get_slide_calls == 0
+
+
+def test_read_full_at_spacing_accepts_slightly_finer_image_without_resize():
+    level0 = np.arange(4 * 4 * 3, dtype=np.uint8).reshape(4, 4, 3)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    out = WSI.read_full_at_spacing(
+        stub,
+        requested_spacing_um=0.49,
+        tolerance=0.05,
+        interpolation="area",
     )
 
     assert out is level0
@@ -179,17 +326,105 @@ def test_read_full_at_spacing_downscales_when_no_level_matches():
 # --------------------------------------------------------------------------- #
 # read_label_at_spacing                                                       #
 # --------------------------------------------------------------------------- #
+def test_read_label_at_spacing_allows_finer_request_with_nearest_replication():
+    labels = np.array([[1, 2], [3, 4]], dtype=np.uint8)
+    level0 = np.repeat(labels[..., np.newaxis], 3, axis=2)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    out = read_label_at_spacing(
+        stub,
+        requested_spacing_um=0.25,
+        tolerance=0.05,
+    )
+
+    expected = np.array(
+        [
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [3, 3, 4, 4],
+            [3, 3, 4, 4],
+        ],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_read_label_region_at_spacing_allows_finer_request_with_nearest_replication():
+    labels = np.array([[1, 2], [3, 4]], dtype=np.uint8)
+    level0 = np.repeat(labels[..., np.newaxis], 3, axis=2)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    out = read_label_region_at_spacing(
+        stub,
+        location=(0, 0),
+        requested_spacing_um=0.25,
+        size=(4, 4),
+        tolerance=0.05,
+    )
+
+    expected = np.array(
+        [
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [3, 3, 4, 4],
+            [3, 3, 4, 4],
+        ],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_read_label_at_spacing_exact_match_preserves_labels():
+    labels = np.array([[1, 2], [3, 4]], dtype=np.uint8)
+    level0 = np.repeat(labels[..., np.newaxis], 3, axis=2)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    out = read_label_at_spacing(
+        stub,
+        requested_spacing_um=0.5,
+        tolerance=0.05,
+    )
+
+    np.testing.assert_array_equal(out, labels)
+
+
+def test_read_label_at_spacing_downsamples_with_exact_nearest_classes():
+    labels = np.array(
+        [
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [3, 3, 4, 4],
+            [3, 3, 4, 4],
+        ],
+        dtype=np.uint8,
+    )
+    level0 = np.repeat(labels[..., np.newaxis], 3, axis=2)
+    stub = _StubWSI(level0_spacing_um=0.5, levels=[level0])
+
+    out = read_label_at_spacing(
+        stub,
+        requested_spacing_um=1.0,
+        tolerance=0.05,
+    )
+
+    expected = np.array([[1, 2], [3, 4]], dtype=np.uint8)
+    np.testing.assert_array_equal(out, expected)
+
+
 class _StubLabelWSI:
     def __init__(self, arr: np.ndarray):
         self._arr = arr
         self.calls: list[dict] = []
 
-    def read_full_at_spacing(self, requested_spacing_um, *, tolerance, interpolation):
+    def read_full_at_spacing(
+        self, requested_spacing_um, *, tolerance, interpolation, content_kind
+    ):
         self.calls.append(
             {
                 "requested_spacing_um": requested_spacing_um,
                 "tolerance": tolerance,
                 "interpolation": interpolation,
+                "content_kind": content_kind,
             }
         )
         return self._arr
@@ -205,7 +440,12 @@ def test_read_label_at_spacing_collapses_channel_replicated_rgb():
     np.testing.assert_array_equal(out, labels)
     # labels must be resampled with nearest-neighbor to avoid inventing ids
     assert stub.calls == [
-        {"requested_spacing_um": 2.0, "tolerance": 0.05, "interpolation": "nearest"}
+        {
+            "requested_spacing_um": 2.0,
+            "tolerance": 0.05,
+            "interpolation": "nearest",
+            "content_kind": "label",
+        }
     ]
 
 


### PR DESCRIPTION
## Summary

- centralize the content-aware spacing-read policy across planner, region, full-image, and tiling paths
- default public reads to image-safe behavior while allowing explicit nearest-neighbour label replication
- remove the duplicate `generate_tiles` spacing guard and route it through the shared image policy
- document the image/label asymmetry and add focused regression coverage

## Root cause

Spacing selection and full-image resizing independently allowed requests finer than level 0, causing image pixels to be upsampled despite the documented contract. Content semantics were not represented explicitly in the shared planning path.

## Impact

Direct image region and full reads now raise before loading pixels when a request is finer than the finest available spacing outside tolerance. Label helpers continue to support finer requests with exact nearest-neighbour replication. Existing exact-match, within-tolerance, and downsampling behavior is preserved.

## Acceptance criteria

- [x] Image planner requests finer than level 0 and outside tolerance raise before returning a plan.
- [x] Region reads default to image-safe behavior and raise before backend access.
- [x] Full reads enforce the same policy before loading a level.
- [x] Finer label region and full reads produce exact nearest-neighbour replicated arrays.
- [x] Slightly finer image requests within tolerance remain unresized.
- [x] Exact-match and downsampling behavior remain unchanged for images and labels.
- [x] Invalid content kinds fail clearly.
- [x] `generate_tiles` uses the centralized image policy after duplicate pre-check removal.
- [x] Docstrings explain image-safe defaults and label behavior.
- [x] Focused planner/read tests and a tiling integration regression cover the change.

## Validation

- focused spacing-read and tiling tests: 33 passed
- full test suite: 468 passed, 3 skipped, 46 deselected
- Standards and Spec reviews against `main`; all findings addressed
- `git diff --check`: clean

Closes #197