### PR TITLE
Add PIL reader for flat raster auto inputs

### DIFF
--- a/.tasks/issue-198-pil.md
+++ b/.tasks/issue-198-pil.md
@@ -1,0 +1,21 @@
+# Issue #198 — PIL flat-raster backend
+
+- [x] Add focused tests proving `.png`, `.jpg`, and `.jpeg` auto-routing is
+      case-insensitive, selects only PIL, and does not alter multi-resolution
+      backend order.
+- [x] Add focused tests for corrupt and oversized flat-raster failures, including
+      the inclusive project-owned pixel ceiling and no fallback/recommendation.
+- [x] Add focused tests for the complete one-level reader protocol, spacing,
+      region padding, thumbnails, cleanup/context management, RGB/RGBA handling,
+      and grayscale/palette label preservation.
+- [x] Implement the smallest PIL reader and format-policy routing needed to make
+      each behavior pass.
+- [x] Register `pil` in runtime/config backend sets and verify requested/resolved
+      provenance.
+- [x] Update README, API, CLI, and release notes to explain flat-raster `auto`
+      selection and distinguish it from `speed.jpeg_backend: pil`.
+- [x] Run targeted tests and the full suite.
+- [x] Review `main...HEAD` along standards and issue-spec axes, fix findings, and
+      re-run the full suite.
+- [x] Commit, push `agent/issue-198-pil`, and open a draft PR containing
+      `Closes #198`.

--- a/README.md
+++ b/README.md
@@ -46,16 +46,25 @@ with the base install. For higher JPEG encoding throughput, install the
 encoder choices are authoritative: hs2p reports a missing optional dependency
 instead of falling back to a different encoder.
 
-The supported backend set is:
+Pillow also provides the base-install flat-raster reader
+(`tiling.backend: pil`). These two settings have different jobs:
+`tiling.backend` chooses the input reader, while `speed.jpeg_backend` chooses
+the tile-output JPEG encoder.
+
+The supported input-reader backend set is:
 
 - `auto`
+- `pil`
 - `cucim`
 - `vips`
 - `openslide`
 - `asap`
 
-`auto` prefers `cucim -> vips -> openslide -> asap`.
-Slide and source-mask paths follow this order independently, using openability only.
+For `.png`, `.jpg`, and `.jpeg` inputs (case-insensitive), `auto` selects only
+PIL. Corrupt, unsupported, or oversized flat rasters fail through PIL without
+probing or recommending a native WSI backend. Other inputs retain the
+`cucim -> vips -> openslide -> asap` openability chain; PIL is never tried for
+them. Slide and source-mask paths apply this format policy independently.
 Because the priority changed, an existing `auto` configuration can resolve to a different
 backend; resumed runs may therefore reject and recompute backend-dependent artifacts. Pin an
 explicit backend when preserving the previous decoder is required.

--- a/docs/adr/0002-independent-mask-backend.md
+++ b/docs/adr/0002-independent-mask-backend.md
@@ -2,6 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-07-21
+- Amended: 2026-07-31 by the flat-raster format policy (#198)
 
 ## Context
 
@@ -15,24 +16,24 @@ cannot), and there was no way to express that without changing the slide backend
 
 `TilingConfig` gains a second field, `mask_backend`, alongside `backend`. The slide backend is
 resolved only from the slide path and the mask backend only from the source-mask path — the two
-roles are independent, and neither role's openability probe influences the other. Both share
-one selection policy: `auto` checks openability only (open then close to pick the first backend
-that opens the file) and never inspects decoded label semantics or retries after selection. A
-selected decoder is authoritative for that read (ADR 0001 still holds).
-The shared automatic priority is cuCIM, VIPS, OpenSlide, then ASAP. A slide probe receives the
-user's level-0 spacing override so it can open a slide with missing native spacing metadata;
-probe-time spacing-conflict warnings are suppressed, and only the selected reader emits the
-contextual warning.
+roles are independent, and neither role's backend resolution influences the
+other. Both share one format-aware selection policy: `auto` selects only PIL for
+`.png`, `.jpg`, and `.jpeg` suffixes, and uses the cuCIM, VIPS, OpenSlide, then
+ASAP openability chain for other inputs. PIL is never included in that chain.
+Selection never inspects decoded label semantics or retries after selection. A
+selected decoder is authoritative for that read (ADR 0001 still holds). A
+native-backend slide probe receives the user's level-0 spacing override so it
+can open a slide with missing native spacing metadata; probe-time
+spacing-conflict warnings are suppressed, and only the selected reader emits
+the contextual warning.
 
-Both fields accept only `auto`, `cucim`, `asap`, `openslide`, `vips`; null and unknown values
+Both fields accept only `auto`, `cucim`, `asap`, `openslide`, `pil`, `vips`; null and unknown values
 fail configuration validation, including when a `TilingConfig` is constructed directly in
 Python (which is keyword-only, and validates the `requested_*` provenance fields on the same
 allowlist). A slide with no source mask never resolves or validates mask-backend availability,
 and its mask provenance is null. An explicit mask backend applies to every source-mask read —
 precomputed tissue masks, annotation masks, the public low-level readers, overlays, and
 deferred preview reads.
-
-The shared `auto` priority is `cucim`, `vips`, `openslide`, then `asap`.
 
 The public low-level mask readers are decoupled from the slide backend: called **without** a
 `mask_backend` (omitted or `None`) they resolve the mask backend independently from the mask
@@ -43,8 +44,10 @@ path via `auto`, never inheriting the slide's backend, and record `requested_mas
 Opening a source mask is centralized through one helper (`open_mask_reader`) so an open failure
 — from backend resolution or the open itself — is reraised with actionable context naming the
 mask path and the requested backend (and the resolved backend when known), rather than a raw
-codec error; the remedy is to set `mask_backend` explicitly. Overlays and the `WSI` attached-mask
-path route through this helper.
+codec error. Native-backend failures recommend setting `mask_backend`
+explicitly; an auto-selected flat PIL failure recommends only verifying the
+file, because the format policy has no fallback. Overlays and the `WSI`
+attached-mask path route through this helper.
 
 Requested and resolved values are kept separate for both roles (`requested_backend` /
 `backend`, `requested_mask_backend` / `mask_backend`) and persisted in the tiling metadata,
@@ -57,8 +60,10 @@ resolved backend, and reason.
 ## Consequences
 
 - A mask can use a different decoder than its slide without changing the slide backend.
-- Because `auto` is openability-only, a backend that opens but cannot decode a mask can be
-  selected and then fail at read time; the fix is to set `mask_backend` explicitly.
+- For non-flat inputs, a native backend that opens but cannot decode a mask can
+  be selected and then fail at read time; the fix is to set `mask_backend`
+  explicitly.
+- Flat raster suffixes fail through PIL without a native-backend fallback.
 - Existing `auto` configurations can resolve to a different backend under the shared priority,
   so backend-dependent artifacts may need to be recomputed.
 - Pre-#163 metadata and `process_list.csv` schemas (without the mask backend fields/columns)

--- a/docs/api.md
+++ b/docs/api.md
@@ -188,17 +188,22 @@ Internally, the shared coordinate engine still uses a generic `mask_path`.
 each support:
 
 - `auto`
+- `pil`
 - `cucim`
 - `vips`
 - `openslide`
 - `asap`
 
-`auto` prefers `cucim -> vips -> openslide -> asap`. Both fields reject null and unknown
-values when the `TilingConfig` is constructed.
+`auto` classifies each input by suffix. `.png`, `.jpg`, and `.jpeg`
+(case-insensitive) select only PIL; a flat-raster open or size failure is final.
+Other inputs use the unchanged `cucim -> vips -> openslide -> asap`
+openability chain, which never considers PIL. Both fields reject null and unknown
+values when the `TilingConfig` is constructed. An explicit backend remains
+authoritative.
 
 The slide backend is resolved from the slide path and the mask backend from the source-mask
-path — independently, with the same openability-only `auto` policy (no label-semantics
-inspection, no retry after selection). An explicit mask backend applies to every source-mask
+path — independently, with the same format-aware `auto` policy (no label-semantics
+inspection and no retry after selection). An explicit mask backend applies to every source-mask
 read: precomputed tissue masks, annotation masks, the low-level readers
 (`resolve_tissue_mask`, `resolve_annotation_masks`, `load_precomputed_tissue_mask`,
 `load_annotation_label_mask`, all of which accept a `mask_backend`), `overlay_mask_on_slide`,
@@ -211,11 +216,17 @@ backend — and records `requested_mask_backend == "auto"`. The high-level pipel
 because it always passes an explicit resolved `mask_backend`. `TilingConfig` is keyword-only, so
 every field (including `mask_backend`) must be passed by name.
 
+`tiling.backend="pil"` is the input reader for flat rasters. It is distinct from
+`speed.jpeg_backend="pil"`, which selects Pillow only as the JPEG encoder for
+saved tile TARs.
+
 Opening a source mask that the selected backend cannot decode fails with actionable context
 naming the mask path and the requested backend (and the resolved backend when known) rather than
 surfacing a raw codec error — for example
 `Mask open failed for path=... with backend=<resolved> (requested=<requested>): <error>. Select
 another mask backend or verify the mask file.` The remedy is to set `mask_backend` explicitly.
+For a flat raster that `auto` assigns to PIL, the error instead asks the caller
+only to verify the file; it does not recommend another backend.
 
 `TilingResult`, `TilingArtifacts`, the tiling metadata, and `process_list.csv` record both the
 requested and resolved slide and mask backends separately (`requested_backend` / `backend` and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,30 +83,38 @@ pip install "hs2p[turbojpeg]"
 pip install "hs2p[all]"
 ```
 
-The base install includes Pillow, the portable default JPEG encoder for tile TAR
-export. The `turbojpeg` extra installs PyTurboJPEG as an optional performance
-backend and is also included in `all`.
+The base install includes Pillow both as the flat-raster input reader
+(`tiling.backend: pil`) and as the portable default JPEG encoder for tile TAR
+export (`speed.jpeg_backend: pil`). These settings are independent: the first
+chooses how hs2p reads an input, while the second chooses how it encodes saved
+tiles. The `turbojpeg` extra installs PyTurboJPEG as an optional performance
+encoder and is also included in `all`.
 
 `tiling.backend` (slide reader) and `tiling.mask_backend` (source-mask reader) both support:
 
 - `auto`
+- `pil`
 - `cucim`
 - `vips`
 - `openslide`
 - `asap`
 
-`auto` prefers `cucim -> vips -> openslide -> asap`. Null and any other value are rejected up
-front by configuration validation (including when constructing `TilingConfig` directly in
-Python).
+For `.png`, `.jpg`, and `.jpeg` inputs (case-insensitive), `auto` selects only
+PIL. A corrupt, unsupported, or oversized flat raster fails through PIL without
+another backend probe or recommendation. Other inputs use the unchanged
+`cucim -> vips -> openslide -> asap` openability chain, which never considers
+PIL. Null and any other value are rejected up front by configuration validation
+(including when constructing `TilingConfig` directly in Python).
 
 ### Independent slide and mask backends
 
 The slide backend and the mask backend are resolved **independently, each from its own path**:
 `tiling.backend` from the slide path, `tiling.mask_backend` from the source-mask path. They
-share the same selection policy — `auto` checks **openability only** (it opens and closes the
-file to pick the first backend that can open it) and never inspects the decoded label
-semantics or retries after selection. A slide with no source mask never resolves or validates
-mask-backend availability, and its mask provenance is recorded as null.
+share the same format-aware selection policy. Flat-raster suffixes route directly
+to PIL; other suffixes use the native-backend openability chain. Neither path
+inspects decoded label semantics or retries after selection. A slide with no
+source mask never resolves or validates mask-backend availability, and its mask
+provenance is recorded as null.
 
 Because `auto` is openability-only, a backend that can *open* but not *decode* a mask (e.g.
 cuCIM opening a deflate-compressed label TIFF whose pixels it cannot decode) can be selected

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,16 +2,30 @@
 
 ## Unreleased
 
-### Shared automatic slide and mask backend priority
+### Format-aware automatic slide and mask backends
 
-Automatic selection now probes both slide and source-mask paths independently with the same
-openability-only priority:
+Flat `.png`, `.jpg`, and `.jpeg` slide or source-mask inputs now select the new
+PIL reader directly under `auto` (case-insensitive). Pillow is a core dependency,
+so ordinary flat benchmark images no longer require libvips or another native
+WSI backend. Flat rasters have one level and require
+`spacing_at_level_0`; PNG/JPEG density metadata is not interpreted as pathology
+spacing. The input-reader setting `tiling.backend: pil` is separate from
+`speed.jpeg_backend: pil`, which selects Pillow as the saved-tile JPEG encoder.
+
+This routing is authoritative: corrupt, unsupported, or oversized flat rasters
+fail through PIL without another backend probe or recommendation. PIL enforces
+the project-owned `PIL_MAX_IMAGE_PIXELS` ceiling before pixel decoding,
+independent of Pillow's mutable global ceiling. Explicit backend choices remain
+authoritative.
+
+Other inputs continue to probe slide and source-mask paths independently with
+the same openability-only priority:
 
 `cucim -> vips -> openslide -> asap`
 
-Explicit backend choices remain authoritative. Automatic selection still stops at the first
-reader that opens a source; it does not inspect mask labels or retry after a later decode
-failure.
+PIL is never considered in that multi-resolution chain. Automatic selection
+still stops at the first reader that opens a source; it does not inspect mask
+labels or retry after a later decode failure.
 
 Slide probes now receive `spacing_at_level_0`, allowing the override to rescue missing native
 spacing metadata during automatic selection. Probe-time spacing-discrepancy warnings are

--- a/hs2p/configs/default.yaml
+++ b/hs2p/configs/default.yaml
@@ -10,8 +10,8 @@ seed: 0 # seed for reproducibility
 
 tiling:
   read_coordinates_from: # path to reusable {sample_id}.coordinates.* artifacts; skips coordinate computation only, while requested TAR/preview outputs still run
-  backend: "auto" # backend to use for slide reading; auto prefers CuCIM when supported and falls back to ASAP/openslide
-  mask_backend: "auto" # backend to use for reading source masks; resolved independently from the mask path (auto uses the same openability-only probe as the slide backend)
+  backend: "auto" # slide reader; auto uses PIL for PNG/JPEG, otherwise cuCIM -> VIPS -> OpenSlide -> ASAP
+  mask_backend: "auto" # source-mask reader; resolved independently with the same format-aware auto policy
   independent_sampling: false # whether to tile each annotation independently (true) or jointly over the union mask (false)
   params:
     requested_spacing_um: 0.5 # spacing at which to tile the slide, in microns per pixel

--- a/hs2p/configs/models.py
+++ b/hs2p/configs/models.py
@@ -9,14 +9,14 @@ AUTO_BACKEND = "auto"
 # registry in ``hs2p.wsi.reader._BACKENDS`` (plus ``auto``); duplicated here so the config
 # layer validates without importing the (heavier) WSI reader package at model-definition time.
 VALID_BACKENDS: frozenset[str] = frozenset(
-    {AUTO_BACKEND, "cucim", "asap", "openslide", "vips"}
+    {AUTO_BACKEND, "cucim", "asap", "openslide", "pil", "vips"}
 )
 
 
 def _validate_backend_name(value: object, *, field: str) -> str:
     """Reject null and unknown backend names for a config field.
 
-    Both ``backend`` and ``mask_backend`` accept only ``auto`` plus the four concrete
+    Both ``backend`` and ``mask_backend`` accept only ``auto`` plus the concrete
     backends. ``None`` and unknown strings are configuration errors — including when a
     :class:`TilingConfig` is constructed directly in Python.
     """
@@ -29,6 +29,7 @@ def _validate_backend_name(value: object, *, field: str) -> str:
             f"tiling.{field} must be one of {sorted(VALID_BACKENDS)}, got {value!r}"
         )
     return value
+
 
 _DEFAULT_TILING = default_config.tiling
 _DEFAULT_TILING_PARAMS = _DEFAULT_TILING.params

--- a/hs2p/tiling/mask.py
+++ b/hs2p/tiling/mask.py
@@ -12,6 +12,7 @@ from hs2p.configs.resolvers import validate_pixel_mapping
 from hs2p.segmentation import segment_tissue_image
 from hs2p.tiling.contours import _normalize_level_downsamples
 from hs2p.tiling.result import ResolvedAnnotationMasks, ResolvedTissueMask, Sam2Thumbnail
+from hs2p.wsi.backends.pil import PILImageTooLargeError
 from hs2p.wsi.reader import (
     AUTO_BACKEND,
     open_slide,
@@ -29,15 +30,18 @@ def _resolve_mask_backend(mask_path: str | Path, mask_backend: str | None) -> st
     """Resolve the concrete backend used to read a source mask, from the mask path alone.
 
     ``mask_backend`` is the *requested* mask backend: a concrete name is authoritative and
-    returned without a probe; ``"auto"`` triggers openability-only auto-selection over the mask
-    path; ``None`` means "not specified by the caller" and maps to ``AUTO_BACKEND`` — a direct
-    low-level caller who omits the backend resolves the mask independently from the mask path,
-    never inheriting the slide's backend. This is the mask-role half of the shared
-    backend-resolution seam (#163): the slide backend is resolved separately from the slide
-    path and never consulted here.
+    returned without a probe; ``"auto"`` applies format-aware selection over the
+    mask path (flat rasters select PIL directly, other inputs use the native
+    openability chain); ``None`` means "not specified by the caller" and maps to
+    ``AUTO_BACKEND`` — a direct low-level caller who omits the backend resolves
+    the mask independently from the mask path, never inheriting the slide's
+    backend. This is the mask-role half of the shared backend-resolution seam
+    (#163): the slide backend is resolved separately from the slide path and
+    never consulted here.
     """
     requested = mask_backend if mask_backend is not None else AUTO_BACKEND
     return resolve_backend(requested, wsi_path=Path(mask_path)).backend
+
 
 # Reading a mask level larger than this many pixels means the mask lacks a pyramid level
 # near the requested segmentation spacing (the read would be downsized to the seg grid
@@ -93,9 +97,14 @@ def _is_label_subset(mask: np.ndarray, *, valid_values: set[int]) -> bool:
 def _raise_mask_decode_error(
     *, label: str, mask_path: str | Path, backend: str, error: Exception
 ) -> NoReturn:
+    remedy = (
+        "Verify the flat raster file."
+        if isinstance(error, PILImageTooLargeError)
+        else "Select another backend or regenerate the mask."
+    )
     message = (
         f"{label} decode failed for path={Path(mask_path)} with backend={backend}: {error}. "
-        "Select another backend or regenerate the mask."
+        f"{remedy}"
     )
     if isinstance(error, ValueError):
         raise ValueError(message) from error

--- a/hs2p/wsi/backends/__init__.py
+++ b/hs2p/wsi/backends/__init__.py
@@ -5,6 +5,13 @@ from hs2p.wsi.backends.cucim import (
     supports_cucim_path,
 )
 from hs2p.wsi.backends.openslide import OpenSlideReader
+from hs2p.wsi.backends.pil import (
+    PIL_MAX_IMAGE_PIXELS,
+    PIL_SUPPORTED_SUFFIXES,
+    PILImageTooLargeError,
+    PILReader,
+    supports_pil_path,
+)
 from hs2p.wsi.backends.vips import VIPSReader, supports_vips_path
 
 __all__ = [
@@ -12,7 +19,12 @@ __all__ = [
     "CUCIM_SUPPORTED_SUFFIXES",
     "CuCIMReader",
     "OpenSlideReader",
+    "PIL_MAX_IMAGE_PIXELS",
+    "PIL_SUPPORTED_SUFFIXES",
+    "PILImageTooLargeError",
+    "PILReader",
     "VIPSReader",
     "supports_cucim_path",
+    "supports_pil_path",
     "supports_vips_path",
 ]

--- a/hs2p/wsi/backends/pil.py
+++ b/hs2p/wsi/backends/pil.py
@@ -1,0 +1,161 @@
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+from hs2p.wsi.backends.common import (
+    paste_region,
+    resolve_level0_spacing,
+    resolve_padded_read_bounds,
+)
+
+
+PIL_SUPPORTED_SUFFIXES = frozenset({".png", ".jpg", ".jpeg"})
+PIL_MAX_IMAGE_PIXELS = 89_478_485
+_PIL_HEADER_LOCK = Lock()
+_LABEL_MODES = frozenset({"1", "I", "I;16", "L", "P"})
+
+
+class PILImageTooLargeError(ValueError):
+    """Raised before decoding a flat raster above the project pixel ceiling."""
+
+
+def supports_pil_path(path: str | Path) -> bool:
+    return Path(path).suffix.lower() in PIL_SUPPORTED_SUFFIXES
+
+
+class PILReader:
+    def __init__(self, path: str | Path, *, spacing_override: float | None = None):
+        self._path = str(path)
+        try:
+            with _PIL_HEADER_LOCK:
+                pillow_ceiling = Image.MAX_IMAGE_PIXELS
+                try:
+                    Image.MAX_IMAGE_PIXELS = None
+                    self._image = Image.open(self._path)
+                finally:
+                    Image.MAX_IMAGE_PIXELS = pillow_ceiling
+        except Exception as exc:
+            raise RuntimeError(
+                f"PIL backend failed to open path={self._path}: {exc}"
+            ) from exc
+        width, height = self.dimensions
+        pixel_count = width * height
+        if pixel_count > PIL_MAX_IMAGE_PIXELS:
+            self._image.close()
+            raise PILImageTooLargeError(
+                "PIL image exceeds the defensive size limit: "
+                f"path={self._path}, dimensions={width}x{height}, "
+                f"pixel_count={pixel_count}, ceiling={PIL_MAX_IMAGE_PIXELS}"
+            )
+        self.native_spacing = None
+        try:
+            self._spacing = resolve_level0_spacing(
+                path=self._path,
+                backend=self.backend_name,
+                native_spacing=self.native_spacing,
+                spacing_override=spacing_override,
+            )
+        except Exception:
+            self._image.close()
+            raise
+
+    @property
+    def backend_name(self) -> str:
+        return "pil"
+
+    @property
+    def dimensions(self) -> tuple[int, int]:
+        return (int(self._image.width), int(self._image.height))
+
+    @property
+    def spacing(self) -> float:
+        return self._spacing
+
+    @property
+    def spacings(self) -> list[float]:
+        return [self._spacing]
+
+    @property
+    def level_count(self) -> int:
+        return 1
+
+    @property
+    def level_dimensions(self) -> list[tuple[int, int]]:
+        return [self.dimensions]
+
+    @property
+    def level_downsamples(self) -> list[tuple[float, float]]:
+        return [(1.0, 1.0)]
+
+    def _array_from_image(self, image: Image.Image) -> np.ndarray:
+        if image.mode in _LABEL_MODES:
+            array = np.asarray(image)
+            if array.dtype == np.bool_:
+                return array.astype(np.uint8)
+            return array
+        return np.asarray(image.convert("RGB"), dtype=np.uint8)
+
+    @staticmethod
+    def _validate_level(level: int) -> None:
+        if int(level) != 0:
+            raise IndexError(f"PIL flat raster has only level 0, got level={level}")
+
+    def read_level(self, level: int) -> np.ndarray:
+        self._validate_level(level)
+        return self._array_from_image(self._image)
+
+    def read_region(
+        self,
+        location: tuple[int, int],
+        level: int,
+        size: tuple[int, int],
+    ) -> np.ndarray:
+        self._validate_level(level)
+        bounds = resolve_padded_read_bounds(
+            location=location,
+            size=size,
+            level_dimensions=self.dimensions,
+            downsample=1.0,
+        )
+        canvas = bounds.canvas
+        if self._image.mode in _LABEL_MODES:
+            dtype = np.uint16 if self._image.mode == "I;16" else np.uint8
+            canvas = np.full((int(size[1]), int(size[0])), 255, dtype=dtype)
+
+        read_width, read_height = bounds.read_size
+        if read_width <= 0 or read_height <= 0:
+            return canvas
+        x, y = bounds.read_location
+        region = self._image.crop(
+            (x, y, x + int(read_width), y + int(read_height))
+        )
+        return paste_region(
+            canvas,
+            self._array_from_image(region),
+            paste_offset=bounds.paste_offset,
+        )
+
+    def get_thumbnail(self, size: tuple[int, int]) -> np.ndarray:
+        thumbnail = self._image.copy()
+        resample = (
+            Image.Resampling.NEAREST
+            if thumbnail.mode in _LABEL_MODES
+            else Image.Resampling.LANCZOS
+        )
+        thumbnail.thumbnail(
+            (max(1, int(size[0])), max(1, int(size[1]))),
+            resample=resample,
+        )
+        return self._array_from_image(thumbnail)
+
+    def close(self) -> None:
+        self._image.close()
+
+    def __enter__(self) -> "PILReader":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()

--- a/hs2p/wsi/reader.py
+++ b/hs2p/wsi/reader.py
@@ -11,8 +11,10 @@ from hs2p.wsi.backends import (
     ASAPReader,
     CuCIMReader,
     OpenSlideReader,
+    PILReader,
     VIPSReader,
     supports_cucim_path,
+    supports_pil_path,
     supports_vips_path,
 )
 from hs2p.wsi.geometry import LevelSelection, select_level, select_level_for_downsample
@@ -112,9 +114,11 @@ def resolve_backends(
 ) -> ResolvedBackends:
     """Resolve slide and mask backends independently from their own paths.
 
-    Slide ``auto`` and mask ``auto`` share the same openability-only selection policy
-    (:func:`resolve_backend`); an explicit backend is authoritative and returned without a
-    probe. A slide with no ``mask_path`` resolves only the slide role.
+    Slide ``auto`` and mask ``auto`` share the same format-aware selection policy
+    (:func:`resolve_backend`): flat raster suffixes select PIL directly, while other
+    suffixes use the native-backend openability chain. An explicit backend is
+    authoritative and returned without a probe. A slide with no ``mask_path``
+    resolves only the slide role.
     """
     requested_slide = (requested_slide_backend or AUTO_BACKEND).strip().lower()
     slide_selection = resolve_backend(
@@ -187,10 +191,19 @@ def _open_vips(
     return VIPSReader(path, spacing_override=spacing_override)
 
 
+def _open_pil(
+    path: str | Path,
+    *,
+    spacing_override: float | None = None,
+) -> SlideReader:
+    return PILReader(path, spacing_override=spacing_override)
+
+
 _BACKENDS: dict[str, _BackendSpec] = {
     "cucim": _BackendSpec("cucim", _open_cucim, supports_cucim_path),
     "asap": _BackendSpec("asap", _open_asap, _supports_all_paths),
     "openslide": _BackendSpec("openslide", _open_openslide, _supports_all_paths),
+    "pil": _BackendSpec("pil", _open_pil, supports_pil_path),
     "vips": _BackendSpec("vips", _open_vips, supports_vips_path),
 }
 
@@ -272,6 +285,13 @@ def resolve_backend(
             tried=(requested_backend,),
         )
 
+    if supports_pil_path(wsi_path):
+        return BackendSelection(
+            backend="pil",
+            reason="selected PIL for flat raster input",
+            tried=("pil",),
+        )
+
     normalized_wsi_path = _normalize_path(wsi_path)
     normalized_mask_path = _normalize_path(mask_path)
     tried: list[str] = []
@@ -322,13 +342,15 @@ def open_mask_reader(
 ) -> tuple[SlideReader, str]:
     """Open a source mask through its own resolved backend, with actionable failures.
 
-    Resolves the mask backend from the mask path alone (``auto`` probes openability; a concrete
-    name is authoritative) and opens the reader, both inside one ``try`` so any failure —
-    resolution *or* open — is reraised with context naming the mask path and the requested
-    backend (and the resolved backend when it got that far). This is the centralized mask-open
-    seam for the visualization/overlay and :class:`~hs2p.wsi.wsi.WSI` attached-mask paths (#163),
-    mirroring :func:`hs2p.tiling.mask._raise_mask_decode_error`: a ``ValueError`` cause reraises
-    as ``ValueError``, anything else as ``RuntimeError``.
+    Resolves the mask backend from the mask path alone (``auto`` applies the
+    format-aware policy; a concrete name is authoritative) and opens the reader,
+    both inside one ``try`` so any failure — resolution *or* open — is reraised
+    with context naming the mask path and the requested backend (and the resolved
+    backend when it got that far). This is the centralized mask-open seam for the
+    visualization/overlay and :class:`~hs2p.wsi.wsi.WSI` attached-mask paths
+    (#163), mirroring :func:`hs2p.tiling.mask._raise_mask_decode_error`: a
+    ``ValueError`` cause reraises as ``ValueError``, anything else as
+    ``RuntimeError``.
 
     Returns ``(reader, resolved_backend)``.
     """
@@ -337,10 +359,16 @@ def open_mask_reader(
         resolved = resolve_backend(mask_backend, wsi_path=Path(mask_path)).backend
         reader = open_slide(mask_path, backend=resolved)
     except Exception as error:
+        requested = (mask_backend or AUTO_BACKEND).strip().lower()
+        remedy = (
+            "Verify the flat raster file."
+            if requested == AUTO_BACKEND and resolved == "pil"
+            else "Select another mask backend or verify the mask file."
+        )
         message = (
             f"Mask open failed for path={Path(mask_path)} with backend={resolved} "
             f"(requested={mask_backend}): {error}. "
-            "Select another mask backend or verify the mask file."
+            f"{remedy}"
         )
         if isinstance(error, ValueError):
             raise ValueError(message) from error

--- a/tests/test_mask_backend_config.py
+++ b/tests/test_mask_backend_config.py
@@ -27,7 +27,7 @@ def test_omitting_mask_backend_defaults_to_auto():
     assert tiling.requested_mask_backend == "auto"
 
 
-@pytest.mark.parametrize("name", ["auto", "cucim", "asap", "openslide", "vips"])
+@pytest.mark.parametrize("name", ["auto", "cucim", "asap", "openslide", "pil", "vips"])
 def test_supported_backend_names_are_accepted(name):
     tiling = _tiling(backend=name, mask_backend=name)
     assert tiling.backend == name

--- a/tests/test_pil_reader.py
+++ b/tests/test_pil_reader.py
@@ -1,0 +1,423 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+import hs2p.wsi.reader as reader_mod
+import hs2p.tiling.mask as mask_mod
+from hs2p.configs import TilingConfig
+from hs2p.wsi.backends import pil as pil_mod
+
+
+@pytest.mark.parametrize("suffix", [".png", ".JPG", ".JpEg"])
+def test_auto_routes_flat_raster_suffixes_only_to_pil(monkeypatch, suffix):
+    def _unexpected_probe(**kwargs):
+        raise AssertionError(f"auto probed a backend for flat input: {kwargs}")
+
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _unexpected_probe)
+
+    selection = reader_mod.resolve_backend(
+        "auto",
+        wsi_path=Path(f"benchmark-image{suffix}"),
+    )
+
+    assert selection.backend == "pil"
+    assert selection.tried == ("pil",)
+    assert "PIL" in (selection.reason or "")
+
+
+@pytest.mark.parametrize(
+    ("filename", "image_format"),
+    [("image.png", "PNG"), ("image.jpg", "JPEG"), ("image.JPEG", "JPEG")],
+)
+def test_auto_opens_small_flat_rasters_without_native_backend_probes(
+    monkeypatch, tmp_path, filename, image_format
+):
+    path = tmp_path / filename
+    Image.fromarray(np.zeros((3, 5, 3), dtype=np.uint8), mode="RGB").save(
+        path,
+        format=image_format,
+    )
+
+    def _unexpected_probe(**kwargs):
+        raise AssertionError(f"auto probed a native backend: {kwargs}")
+
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _unexpected_probe)
+
+    with reader_mod.open_slide(
+        path,
+        backend="auto",
+        spacing_override=0.25,
+    ) as slide:
+        assert slide.backend_name == "pil"
+        assert slide.dimensions == (5, 3)
+
+
+def test_pil_reader_reports_one_level_geometry_and_explicit_spacing(tmp_path):
+    path = tmp_path / "labels.png"
+    Image.fromarray(np.zeros((4, 6), dtype=np.uint8), mode="L").save(path)
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.375,
+    ) as slide:
+        assert slide.native_spacing is None
+        assert slide.spacing == 0.375
+        assert slide.spacings == [0.375]
+        assert slide.level_count == 1
+        assert slide.level_dimensions == [(6, 4)]
+        assert slide.level_downsamples == [(1.0, 1.0)]
+
+
+def test_pil_reader_requires_explicit_level_zero_spacing(tmp_path):
+    path = tmp_path / "image.png"
+    Image.fromarray(np.zeros((2, 3, 3), dtype=np.uint8), mode="RGB").save(path)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Unable to infer slide spacing.*backend=pil.*spacing_at_level_0",
+    ):
+        reader_mod.open_slide(path, backend="pil")
+
+
+def test_pil_reader_uses_the_project_owned_pixel_ceiling():
+    assert pil_mod.PIL_MAX_IMAGE_PIXELS == 89_478_485
+
+
+def test_pil_reader_accepts_an_image_at_the_project_pixel_ceiling(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "at-limit.png"
+    Image.fromarray(np.zeros((2, 3), dtype=np.uint8), mode="L").save(path)
+    monkeypatch.setattr(pil_mod, "PIL_MAX_IMAGE_PIXELS", 6)
+    monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 1)
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        assert slide.dimensions == (3, 2)
+
+    assert Image.MAX_IMAGE_PIXELS == 1
+
+
+def test_auto_rejects_one_pixel_above_the_pil_ceiling_before_decode(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "too-large.PNG"
+    Image.fromarray(np.zeros((2, 3), dtype=np.uint8), mode="L").save(path)
+    monkeypatch.setattr(pil_mod, "PIL_MAX_IMAGE_PIXELS", 5)
+
+    def _unexpected_decode(self, *args, **kwargs):
+        raise AssertionError("oversized image pixel data was decoded")
+
+    def _unexpected_probe(**kwargs):
+        raise AssertionError(f"auto probed an alternative backend: {kwargs}")
+
+    monkeypatch.setattr(Image.Image, "load", _unexpected_decode)
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _unexpected_probe)
+
+    with pytest.raises(ValueError) as caught:
+        reader_mod.open_slide(
+            path,
+            backend="auto",
+            spacing_override=0.5,
+        )
+
+    message = str(caught.value)
+    assert str(path) in message
+    assert "dimensions=3x2" in message
+    assert "pixel_count=6" in message
+    assert "ceiling=5" in message
+    assert "another backend" not in message.lower()
+
+
+def test_auto_mask_oversize_error_does_not_recommend_another_backend(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "too-large-mask.png"
+    Image.fromarray(np.zeros((2, 3), dtype=np.uint8), mode="L").save(path)
+    monkeypatch.setattr(pil_mod, "PIL_MAX_IMAGE_PIXELS", 5)
+
+    with pytest.raises(ValueError) as caught:
+        reader_mod.open_mask_reader(path, mask_backend="auto")
+
+    message = str(caught.value)
+    assert "backend=pil" in message
+    assert "ceiling=5" in message
+    assert "another" not in message.lower()
+    assert "select" not in message.lower()
+
+
+def test_tiling_mask_oversize_error_does_not_recommend_another_backend(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "too-large-tiling-mask.png"
+    Image.fromarray(np.zeros((2, 3), dtype=np.uint8), mode="L").save(path)
+    monkeypatch.setattr(pil_mod, "PIL_MAX_IMAGE_PIXELS", 5)
+
+    with pytest.raises(ValueError) as caught:
+        mask_mod.load_precomputed_tissue_mask(
+            mask_path=path,
+            slide=object(),
+            seg_level=0,
+            tissue_value=1,
+            mask_backend="auto",
+        )
+
+    message = str(caught.value)
+    assert "backend=pil" in message
+    assert "ceiling=5" in message
+    assert "another" not in message.lower()
+    assert "select" not in message.lower()
+
+
+def test_corrupt_flat_raster_fails_with_pil_context_and_no_fallback(
+    monkeypatch, tmp_path
+):
+    path = tmp_path / "corrupt.jpeg"
+    path.write_bytes(b"not an image")
+
+    def _unexpected_probe(**kwargs):
+        raise AssertionError(f"auto probed an alternative backend: {kwargs}")
+
+    monkeypatch.setattr(reader_mod, "_backend_can_open_source", _unexpected_probe)
+
+    with pytest.raises(RuntimeError) as caught:
+        reader_mod.open_slide(
+            path,
+            backend="auto",
+            spacing_override=0.5,
+        )
+
+    message = str(caught.value)
+    assert "PIL backend failed to open" in message
+    assert str(path) in message
+    assert "another backend" not in message.lower()
+
+
+@pytest.mark.parametrize(
+    ("mode", "source", "expected"),
+    [
+        (
+            "RGB",
+            np.array(
+                [
+                    [[1, 2, 3], [4, 5, 6]],
+                    [[7, 8, 9], [10, 11, 12]],
+                ],
+                dtype=np.uint8,
+            ),
+            np.array(
+                [
+                    [[1, 2, 3], [4, 5, 6]],
+                    [[7, 8, 9], [10, 11, 12]],
+                ],
+                dtype=np.uint8,
+            ),
+        ),
+        (
+            "RGBA",
+            np.array(
+                [
+                    [[1, 2, 3, 40], [4, 5, 6, 50]],
+                    [[7, 8, 9, 60], [10, 11, 12, 70]],
+                ],
+                dtype=np.uint8,
+            ),
+            np.array(
+                [
+                    [[1, 2, 3], [4, 5, 6]],
+                    [[7, 8, 9], [10, 11, 12]],
+                ],
+                dtype=np.uint8,
+            ),
+        ),
+    ],
+)
+def test_rgb_like_level_reads_are_exact_rgb_uint8(
+    tmp_path, mode, source, expected
+):
+    path = tmp_path / f"{mode.lower()}.png"
+    Image.fromarray(source, mode=mode).save(path)
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        actual = slide.read_level(0)
+
+    assert actual.dtype == np.uint8
+    assert actual.shape == (2, 2, 3)
+    np.testing.assert_array_equal(actual, expected)
+
+
+@pytest.mark.parametrize("mode", ["L", "P"])
+def test_grayscale_and_palette_level_reads_preserve_label_values(tmp_path, mode):
+    labels = np.array([[0, 3, 17], [255, 8, 1]], dtype=np.uint8)
+    image = Image.fromarray(labels, mode=mode)
+    if mode == "P":
+        palette = []
+        for index in range(256):
+            palette.extend(((index * 13) % 256, (index * 29) % 256, 255 - index))
+        image.putpalette(palette)
+    path = tmp_path / f"labels-{mode}.png"
+    image.save(path)
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        actual = slide.read_level(0)
+
+    assert actual.dtype == np.uint8
+    assert actual.shape == (2, 3)
+    np.testing.assert_array_equal(actual, labels)
+
+
+def test_uint16_grayscale_reads_preserve_label_values_and_dtype(tmp_path):
+    labels = np.array([[0, 300, 65_535], [42, 1_024, 7]], dtype=np.uint16)
+    path = tmp_path / "labels-uint16.png"
+    Image.fromarray(labels).save(path)
+    expected_region = np.full((3, 5), 255, dtype=np.uint16)
+    expected_region[1:3, 1:4] = labels
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        level = slide.read_level(0)
+        region = slide.read_region((-1, -1), 0, (5, 3))
+
+    assert level.dtype == np.uint16
+    assert level.shape == (2, 3)
+    np.testing.assert_array_equal(level, labels)
+    np.testing.assert_array_equal(region, expected_region)
+
+
+def test_one_bit_grayscale_reads_return_integer_label_values(tmp_path):
+    labels = np.array([[0, 1, 0], [1, 1, 0]], dtype=np.uint8)
+    path = tmp_path / "labels-one-bit.png"
+    Image.fromarray(labels.astype(bool)).save(path)
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        actual = slide.read_level(0)
+
+    assert actual.dtype == np.uint8
+    np.testing.assert_array_equal(actual, labels)
+
+
+def test_pil_region_read_uses_white_out_of_bounds_padding(tmp_path):
+    source = np.array(
+        [
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            [[10, 11, 12], [13, 14, 15], [16, 17, 18]],
+        ],
+        dtype=np.uint8,
+    )
+    path = tmp_path / "rgb.png"
+    Image.fromarray(source, mode="RGB").save(path)
+    expected = np.full((4, 5, 3), 255, dtype=np.uint8)
+    expected[1:3, 1:4] = source
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        actual = slide.read_region((-1, -1), 0, (5, 4))
+
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_pil_thumbnail_fits_inside_requested_size_as_rgb_uint8(tmp_path):
+    source = np.full((2, 4, 3), [12, 34, 56], dtype=np.uint8)
+    path = tmp_path / "thumbnail.png"
+    Image.fromarray(source, mode="RGB").save(path)
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        thumbnail = slide.get_thumbnail((2, 2))
+
+    assert thumbnail.dtype == np.uint8
+    assert thumbnail.shape == (1, 2, 3)
+    np.testing.assert_array_equal(
+        thumbnail,
+        np.full((1, 2, 3), [12, 34, 56], dtype=np.uint8),
+    )
+
+
+def test_pil_reader_conforms_to_protocol_and_context_manager_closes_it(tmp_path):
+    path = tmp_path / "context.png"
+    Image.fromarray(np.zeros((2, 2, 3), dtype=np.uint8), mode="RGB").save(path)
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        assert isinstance(slide, reader_mod.SlideReader)
+        reader = slide
+
+    reader.close()
+    with pytest.raises(ValueError, match="closed"):
+        reader.read_level(0)
+
+
+def test_palette_region_read_preserves_indices_and_single_channel_shape(tmp_path):
+    labels = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
+    image = Image.fromarray(labels, mode="P")
+    image.putpalette([channel for index in range(256) for channel in (index, 0, 0)])
+    path = tmp_path / "palette.png"
+    image.save(path)
+    expected = np.full((3, 3), 255, dtype=np.uint8)
+    expected[:2, :2] = labels[:, 1:]
+
+    with reader_mod.open_slide(
+        path,
+        backend="pil",
+        spacing_override=0.5,
+    ) as slide:
+        actual = slide.read_region((1, 0), 0, (3, 3))
+
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_pil_is_a_supported_tiling_backend():
+    config = TilingConfig(
+        requested_spacing_um=0.5,
+        requested_tile_size_px=256,
+        tolerance=0.05,
+        overlap=0.0,
+        min_coverage={"tissue": 0.1},
+        backend="pil",
+        mask_backend="pil",
+    )
+
+    assert config.backend == "pil"
+    assert config.mask_backend == "pil"
+
+
+def test_flat_raster_resolution_records_requested_and_resolved_provenance():
+    resolved = reader_mod.resolve_backends(
+        requested_slide_backend="auto",
+        requested_mask_backend=None,
+        wsi_path=Path("benchmark.png"),
+    )
+
+    assert resolved.requested_slide_backend == "auto"
+    assert resolved.slide.backend == "pil"
+    assert resolved.slide.tried == ("pil",)


### PR DESCRIPTION
## Summary

- add a complete one-level `PILReader` for PNG/JPEG inputs, including label-preserving reads and white padding
- route `.png`, `.jpg`, and `.jpeg` directly to PIL under `auto` without probing native WSI backends
- enforce a project-owned pre-decode pixel ceiling independent of Pillow's mutable global
- register `pil` in runtime/configuration provenance and document the split automatic policy

## Why

Flat benchmark rasters previously entered the native WSI backend chain even though Pillow is already a core dependency. This made ordinary PNG/JPEG inputs depend on native libraries such as libvips.

## Validation

- `pytest -q` — 481 passed, 3 skipped, 46 deselected
- focused backend/reader/mask regressions — 121 passed, 3 skipped
- focused `flake8` and `git diff --check`
- two-axis review against `main`; fixed the oversized auto-mask recommendation finding

Flat label rasters are covered at the reader seam with an explicit level-zero spacing override, as required by the spacing contract. This change intentionally does not add mask-spacing geometry or a new high-level mask-spacing API.

Closes #198