### PR TITLE
Speed up tiling previews

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Faster tiling previews
+
+Tiling previews (`preview.save_tiling_preview`) are now rendered by drawing the
+grid directly on the loaded slide canvas when no annotation overlay is requested,
+instead of cropping and re-pasting every tile. The overlay path is unchanged. The
+preview stage also runs in up to `speed.num_workers` spawned processes rather
+than threads, including when previews are materialized from reusable coordinate
+artifacts. A single worker renders inline to avoid process startup and backend
+re-import overhead. On dense prostatectomy slides (60k-190k tiles) this cuts the
+preview stage from ~19 s to ~2 s per slide with 16 workers. Grid lines are now
+complete: the previous per-tile paste erased the shared edge of already-drawn
+neighbours when tiles did not fall on whole preview pixels.
+
 ### Format-aware automatic slide and mask backends
 
 Flat `.png`, `.jpg`, and `.jpeg` slide or source-mask inputs now select the new

--- a/hs2p/tiling/orchestration.py
+++ b/hs2p/tiling/orchestration.py
@@ -4,7 +4,7 @@ import logging
 import multiprocessing as mp
 import traceback
 import warnings
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -1197,6 +1197,34 @@ def _process_pool_context():
     return mp.get_context("spawn")
 
 
+class _InlineExecutor:
+    """Executor that runs each submission synchronously in the calling process.
+
+    Used for tiling previews when there is a single worker: no spawn cost and no
+    slide-backend re-import in a child process.
+    """
+
+    class _DeferredFuture:
+        # Runs on first ``result()`` so errors surface there, like a real future.
+        def __init__(self, fn, kwargs):
+            self._fn = fn
+            self._kwargs = kwargs
+            self._done = False
+            self._value = None
+
+        def result(self):
+            if not self._done:
+                self._value = self._fn(**self._kwargs)
+                self._done = True
+            return self._value
+
+    def submit(self, fn, **kwargs):
+        return self._DeferredFuture(fn, kwargs)
+
+    def shutdown(self, wait=True):
+        return None
+
+
 def _write_tiling_preview_from_artifacts(
     *,
     artifact: TilingArtifacts,
@@ -1532,16 +1560,28 @@ def tile_slides(
         for request in compute_requests
         if request.input_index not in mask_failures
     ]
-    use_slide_pool, pool_processes, worker_inner_workers = _resolve_tiling_worker_allocation(
-        num_workers=num_workers,
-        compute_count=len(compute_requests),
+    use_slide_pool, compute_pool_processes, worker_inner_workers = (
+        _resolve_tiling_worker_allocation(
+            num_workers=num_workers,
+            compute_count=len(compute_requests),
+        )
     )
     compute_pool_module = _process_pool_context()
-    preview_executor = (
-        ThreadPoolExecutor(max_workers=max(1, pool_processes))
-        if preview is not None and preview.save_tiling_preview
-        else None
-    )
+    # Tiling previews are CPU-bound Python (per-tile grid drawing + JPEG encode), so a
+    # thread pool serialises on the GIL and ends up slower than a single thread. Use
+    # spawned processes, like the tiling pools (see ``_process_pool_context``).
+    preview_executor = None
+    if preview is not None and preview.save_tiling_preview:
+        preview_worker_count = max(1, int(num_workers))
+        if preview_worker_count > 1:
+            preview_executor = ProcessPoolExecutor(
+                max_workers=preview_worker_count,
+                mp_context=compute_pool_module,
+                initializer=_configure_worker_logging,
+                initargs=(str(output_dir),),
+            )
+        else:
+            preview_executor = _InlineExecutor()
     pending_previews: list[_PendingPreview] = []
     total_slides = len(planned_work)
 
@@ -1877,7 +1917,7 @@ def tile_slides(
                 for request in compute_requests
             ]
             with compute_pool_module.Pool(
-                processes=pool_processes,
+                processes=compute_pool_processes,
                 initializer=_configure_worker_logging,
                 initargs=(str(output_dir),),
             ) as pool:

--- a/hs2p/wsi/preview.py
+++ b/hs2p/wsi/preview.py
@@ -88,7 +88,6 @@ def draw_grid_from_coordinates(
     color_mapping: dict[str, list[int] | None] | None = None,
 ):
     downsamples = wsi.level_downsamples[vis_level]
-    source_canvas = canvas[:, :, :3].copy()
     if indices is None:
         indices = np.arange(len(coords))
     total = len(indices)
@@ -109,6 +108,18 @@ def draw_grid_from_coordinates(
         if aligned_mask.ndim == 3 and aligned_mask.shape[-1] == 1:
             aligned_mask = np.squeeze(aligned_mask, axis=-1)
 
+    if aligned_mask is None:
+        # No overlay: the canvas already holds the slide pixels, so only the grid
+        # lines need drawing. Skips the per-tile crop/convert/write-back below,
+        # which is an identity op here and dominates preview time on dense slides.
+        for idx in range(total):
+            coord = np.ceil(
+                np.asarray(coords[indices[idx]], dtype=np.float64) / np.asarray(downsamples)
+            ).astype(np.int32)
+            draw_grid(canvas, coord, tile_size, thickness=thickness)
+        return Image.fromarray(canvas)
+
+    source_canvas = canvas[:, :, :3].copy()
     for idx in range(total):
         tile_id = indices[idx]
         coord = coords[tile_id]

--- a/tests/test_coordinate_reuse_outputs.py
+++ b/tests/test_coordinate_reuse_outputs.py
@@ -28,8 +28,9 @@ def _saved_coordinates(
     tmp_path: Path,
     *,
     coords: list[tuple[int, int]],
+    sample_id: str = "reuse-slide",
 ) -> tuple[SlideSpec, Path]:
-    slide = SlideSpec(sample_id="reuse-slide", image_path=Path("reuse-slide.svs"))
+    slide = SlideSpec(sample_id=sample_id, image_path=Path(f"{sample_id}.svs"))
     coordinates = np.asarray(coords, dtype=np.int64).reshape((-1, 2))
     result = preprocessing.TilingResult(
         tiles=preprocessing.TileGeometry(
@@ -175,6 +176,87 @@ def test_reused_coordinates_materialize_requested_tar_manifest_and_preview(
     assert Path(row["coordinates_meta_path"]) == artifact.coordinates_meta_path
     assert Path(row["tiles_tar_path"]) == expected_tar
     assert Path(row["tiling_preview_path"]) == expected_preview
+
+
+def test_reused_coordinate_previews_use_configured_process_capacity(
+    monkeypatch,
+    tmp_path: Path,
+):
+    first_slide, coordinates_dir = _saved_coordinates(
+        tmp_path,
+        coords=[(0, 0)],
+        sample_id="reuse-1",
+    )
+    second_slide, second_coordinates_dir = _saved_coordinates(
+        tmp_path,
+        coords=[(16, 0)],
+        sample_id="reuse-2",
+    )
+    assert second_coordinates_dir == coordinates_dir
+    _install_fake_slide_reader(monkeypatch)
+
+    seen: dict[str, object] = {}
+    submitted: list[str] = []
+
+    class _DeferredFuture:
+        def __init__(self, fn, kwargs):
+            self._fn = fn
+            self._kwargs = kwargs
+
+        def result(self):
+            return self._fn(**self._kwargs)
+
+    class _RecordingProcessPoolExecutor:
+        def __init__(
+            self,
+            max_workers,
+            *,
+            mp_context,
+            initializer,
+            initargs,
+        ):
+            seen["max_workers"] = max_workers
+            seen["mp_context"] = mp_context
+            seen["initializer"] = initializer
+            seen["initargs"] = initargs
+
+        def submit(self, fn, **kwargs):
+            submitted.append(kwargs["result"].sample_id)
+            return _DeferredFuture(fn, kwargs)
+
+        def shutdown(self, wait=True):
+            seen["shutdown_wait"] = wait
+
+    monkeypatch.setattr(
+        orchestration,
+        "ProcessPoolExecutor",
+        _RecordingProcessPoolExecutor,
+    )
+
+    output_dir = tmp_path / "run"
+    artifacts = tile_slides(
+        [first_slide, second_slide],
+        tiling=_tiling_config(),
+        segmentation=_segmentation_config(),
+        filtering=_filter_config(),
+        preview=PreviewConfig(save_tiling_preview=True, downsample=2),
+        output_dir=output_dir,
+        num_workers=4,
+        read_coordinates_from=coordinates_dir,
+    )
+
+    assert submitted == ["reuse-1", "reuse-2"]
+    assert seen == {
+        "max_workers": 4,
+        "mp_context": orchestration._process_pool_context(),
+        "initializer": orchestration._configure_worker_logging,
+        "initargs": (str(output_dir),),
+        "shutdown_wait": True,
+    }
+    assert [artifact.tiling_preview_path for artifact in artifacts] == [
+        output_dir / "preview" / "tiling" / "reuse-1.jpg",
+        output_dir / "preview" / "tiling" / "reuse-2.jpg",
+    ]
 
 
 def test_reused_zero_tile_coordinates_do_not_fabricate_a_preview(

--- a/tests/test_overlay_semantics.py
+++ b/tests/test_overlay_semantics.py
@@ -502,3 +502,43 @@ def test_draw_grid_from_coordinates_crops_loaded_canvas_instead_of_fetching_tile
 
     rendered = np.array(image)
     assert rendered.shape == canvas.shape
+
+
+def test_draw_grid_from_coordinates_no_mask_preserves_fractional_projected_edges():
+    class FakeWSI:
+        level_downsamples = [(1.0, 1.0), (1.3, 1.3)]
+        level_dimensions = [(8, 7), (8, 7)]
+        spacings = [0.25, 0.325]
+
+        def get_level_spacing(self, level):
+            return self.spacings[level]
+
+    canvas = np.full((7, 8, 3), 255, dtype=np.uint8)
+    rendered = np.array(
+        wsi_mod.draw_grid_from_coordinates(
+            canvas.copy(),
+            FakeWSI(),
+            coords=[(0, 0), (2, 0)],
+            tile_size_at_0=(3, 3),
+            vis_level=1,
+            thickness=1,
+            mask=None,
+        )
+    )
+
+    expected_black = np.array(
+        [
+            [True, True, True, True, True, True, False, False],
+            [True, False, True, True, False, True, False, False],
+            [True, False, True, True, False, True, False, False],
+            [True, True, True, True, True, True, False, False],
+            [False, False, False, False, False, False, False, False],
+            [False, False, False, False, False, False, False, False],
+            [False, False, False, False, False, False, False, False],
+        ],
+        dtype=bool,
+    )
+    expected = np.full_like(canvas, 255)
+    expected[expected_black] = 0
+
+    np.testing.assert_array_equal(rendered, expected)

--- a/tests/test_tiling_api.py
+++ b/tests/test_tiling_api.py
@@ -1058,28 +1058,9 @@ def test_tile_slides_defers_preview_writes_until_after_next_slide_compute(
         path.write_bytes(b"preview")
         return path
 
-    class _FakeFuture:
-        def __init__(self, fn, kwargs):
-            self._fn = fn
-            self._kwargs = kwargs
-
-        def result(self):
-            return self._fn(**self._kwargs)
-
-    class _FakeThreadPoolExecutor:
-        def __init__(self, max_workers):
-            assert max_workers == 1
-
-        def submit(self, fn, **kwargs):
-            return _FakeFuture(fn, kwargs)
-
-        def shutdown(self, wait=True):
-            return None
-
     monkeypatch.setattr("hs2p.tiling.orchestration._compute_tiling_result", _fake_compute_tiling_result)
     monkeypatch.setattr("hs2p.tiling.orchestration.save_tiling_result", _fake_save_tiling_result)
     monkeypatch.setattr("hs2p.tiling.orchestration.write_tiling_preview", _fake_write_tiling_preview)
-    monkeypatch.setattr("hs2p.tiling.orchestration.ThreadPoolExecutor", _FakeThreadPoolExecutor)
 
     artifacts = tile_slides(
         [


### PR DESCRIPTION
## Summary

Tiling previews (`preview.save_tiling_preview`) took ~19 s/slide on dense prostatectomy slides (60k–190k tiles) with 16 workers — slower than a single thread. Two causes, two fixes:

- **`draw_grid_from_coordinates`**: without an annotation overlay, the per-tile loop cropped and re-pasted every tile from a copy of the canvas — an identity op that dominated preview time. The no-overlay path now just draws the grid lines on the loaded canvas (and skips the full-canvas copy). Overlay path unchanged.
- **Preview executor**: `ThreadPoolExecutor` → spawn `ProcessPoolExecutor` (same context + logging initializer as the tiling pools). The work is CPU-bound Python, so threads serialised on the GIL. Sized by `num_workers` so the `read_coordinates_from` reuse path (no compute pool) also parallelises. A single worker renders inline (no spawn, no backend re-import).

## Measurements

16 task-3 prostatectomy slides (1.37 M tiles), 16 workers, ASAP backend, end-to-end `tile_slides` with previews on:

| | total | preview stage | per slide |
|---|---|---|---|
| 4.4.1 | 374 s | ~300 s | 18.8 s |
| this PR | 104 s | ~31 s | ~2 s |

(74 s of the total is the tiling itself.)

## Render equivalence

Pre-JPEG diff on a real slide: the only differing pixels are grid-line pixels the old loop *erased* — it drew tile k's rectangle, then pasted tile k+1 from the pre-draw copy over the shared edge whenever tiles did not land on whole preview pixels. Zero pixels differ the other way. Grid lines are now complete; otherwise identical.

## Tests

- New: pinned-pixel test for the no-overlay path at a fractional downsample; reuse-path test asserting the preview executor is built with `num_workers`, spawn context, logging initializer.
- `test_tile_slides_defers_preview_writes_until_after_next_slide_compute` now runs the real inline executor.
- Full suite: 500 passed, 3 skipped.